### PR TITLE
Add http headers support for write api.

### DIFF
--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -186,12 +186,10 @@ func ParseArg(arg string) (Config, error) {
 		c.KeepNameTag = null.BoolFrom(v)
 	}
 
+	c.Headers = make(map[string]string)
 	if v, ok := params["headers"].(map[string]interface{}); ok {
 		for k, v := range v {
 			if v, ok := v.(string); ok {
-				if c.Headers == nil {
-					c.Headers = make(map[string]string)
-				}
 				c.Headers[k] = v
 			}
 		}
@@ -226,7 +224,7 @@ func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, a
 	getEnvMap := func(env map[string]string, prefix string) map[string]string {
 		result := make(map[string]string)
 		for ek, ev := range env {
-			if strings.HasPrefix(ev, prefix) {
+			if strings.HasPrefix(ek, prefix) {
 				k := strings.TrimPrefix(ek, prefix)
 				result[k] = ev
 			}
@@ -286,7 +284,12 @@ func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, a
 		}
 	}
 
-	result.Headers = getEnvMap(env, "K6_PROMETHEUS_HEADERS_")
+	envHeaders := getEnvMap(env, "K6_PROMETHEUS_HEADERS_")
+	for k, v := range envHeaders {
+		if _, ok := result.Headers[k]; !ok {
+			result.Headers[k] = v
+		}
+	}
 
 	if arg != "" {
 		argConf, err := ParseArg(arg)

--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/kubernetes/helm/pkg/strvals"
@@ -24,6 +25,8 @@ type Config struct {
 	Mapping null.String `json:"mapping" envconfig:"K6_PROMETHEUS_MAPPING"`
 
 	Url null.String `json:"url" envconfig:"K6_PROMETHEUS_REMOTE_URL"` // here, in the name of env variable, we assume that we won't need to distinguish between remote write URL vs remote read URL
+
+	Headers map[string]string `json:"headers" envconfig:"K6_PROMETHEUS_HEADERS"`
 
 	InsecureSkipTLSVerify null.Bool   `json:"insecureSkipTLSVerify" envconfig:"K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY"`
 	CACert                null.String `json:"caCertFile" envconfig:"K6_CA_CERT_FILE"`
@@ -48,6 +51,7 @@ func NewConfig() Config {
 		FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
 		KeepTags:              null.BoolFrom(true),
 		KeepNameTag:           null.BoolFrom(false),
+		Headers:               make(map[string]string),
 	}
 }
 
@@ -83,6 +87,7 @@ func (conf Config) ConstructRemoteConfig() (*remote.ClientConfig, error) {
 		Timeout:          model.Duration(defaultPrometheusTimeout),
 		HTTPClientConfig: httpConfig,
 		RetryOnRateLimit: true,
+		Headers:          conf.Headers,
 	}
 	return &remoteConfig, nil
 }
@@ -124,6 +129,12 @@ func (base Config) Apply(applied Config) Config {
 
 	if applied.KeepNameTag.Valid {
 		base.KeepNameTag = applied.KeepNameTag
+	}
+
+	if len(applied.Headers) > 0 {
+		for k, v := range applied.Headers {
+			base.Headers[k] = v
+		}
 	}
 
 	return base
@@ -175,6 +186,17 @@ func ParseArg(arg string) (Config, error) {
 		c.KeepNameTag = null.BoolFrom(v)
 	}
 
+	if v, ok := params["headers"].(map[string]interface{}); ok {
+		for k, v := range v {
+			if v, ok := v.(string); ok {
+				if c.Headers == nil {
+					c.Headers = make(map[string]string)
+				}
+				c.Headers[k] = v
+			}
+		}
+	}
+
 	return c, nil
 }
 
@@ -199,6 +221,17 @@ func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, a
 			}
 		}
 		return null.NewBool(false, false), nil
+	}
+
+	getEnvMap := func(env map[string]string, prefix string) map[string]string {
+		result := make(map[string]string)
+		for ek, ev := range env {
+			if strings.HasPrefix(ev, prefix) {
+				k := strings.TrimPrefix(ek, prefix)
+				result[k] = ev
+			}
+		}
+		return result
 	}
 
 	// envconfig is not processing some undefined vars (at least duration) so apply them manually
@@ -252,6 +285,8 @@ func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, a
 			result.KeepNameTag = b
 		}
 	}
+
+	result.Headers = getEnvMap(env, "K6_PROMETHEUS_HEADERS_")
 
 	if arg != "" {
 		argConf, err := ParseArg(arg)

--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -286,9 +286,7 @@ func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, a
 
 	envHeaders := getEnvMap(env, "K6_PROMETHEUS_HEADERS_")
 	for k, v := range envHeaders {
-		if _, ok := result.Headers[k]; !ok {
-			result.Headers[k] = v
-		}
+		result.Headers[k] = v
 	}
 
 	if arg != "" {

--- a/pkg/remotewrite/config_test.go
+++ b/pkg/remotewrite/config_test.go
@@ -117,6 +117,7 @@ func TestConstructRemoteConfig(t *testing.T) {
 				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
 				KeepTags:              null.BoolFrom(true),
 				KeepNameTag:           null.BoolFrom(false),
+				Headers:               make(map[string]string),
 			},
 			errString: "",
 			remoteConfig: &remote.ClientConfig{
@@ -145,6 +146,7 @@ func TestConstructRemoteConfig(t *testing.T) {
 				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
 				KeepTags:              null.BoolFrom(true),
 				KeepNameTag:           null.BoolFrom(false),
+				Headers:               make(map[string]string),
 			},
 			errString: "",
 			remoteConfig: &remote.ClientConfig{
@@ -241,6 +243,7 @@ func assertConfig(t *testing.T, actual, expected Config) {
 	assert.Equal(t, expected.FlushPeriod, actual.FlushPeriod)
 	assert.Equal(t, expected.KeepTags, actual.KeepTags)
 	assert.Equal(t, expected.KeepNameTag, expected.KeepNameTag)
+	assert.Equal(t, expected.Headers, actual.Headers)
 }
 
 func assertRemoteConfig(t *testing.T, actual, expected *remote.ClientConfig) {

--- a/pkg/remotewrite/config_test.go
+++ b/pkg/remotewrite/config_test.go
@@ -180,7 +180,7 @@ func TestConstructRemoteConfig(t *testing.T) {
 			errString:    "strconv.ParseBool",
 			remoteConfig: nil,
 		},
-		"remote_write_with_headers": {
+		"remote_write_with_headers_json": {
 			jsonRaw: json.RawMessage(fmt.Sprintf(`{"url":"%s","mapping":"mapping", "headers":{"X-Header":"value"}}`, u.String())),
 			env:     nil,
 			arg:     "",
@@ -211,6 +211,78 @@ func TestConstructRemoteConfig(t *testing.T) {
 				RetryOnRateLimit: false,
 				Headers: map[string]string{
 					"X-Header": "value",
+				},
+			},
+		},
+		"remote_write_with_headers_env": {
+			jsonRaw: json.RawMessage(fmt.Sprintf(`{"url":"%s","mapping":"mapping", "headers":{"X-Header":"value"}}`, u.String())),
+			env: map[string]string{
+				"K6_PROMETHEUS_HEADERS_X-Header": "value_from_env",
+			},
+			arg: "",
+			config: Config{
+				Mapping:               null.NewString("mapping", true),
+				Url:                   null.StringFrom(u.String()),
+				InsecureSkipTLSVerify: null.BoolFrom(true),
+				CACert:                null.NewString("", false),
+				User:                  null.NewString("", false),
+				Password:              null.NewString("", false),
+				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
+				KeepTags:              null.BoolFrom(true),
+				KeepNameTag:           null.BoolFrom(false),
+				Headers: map[string]string{
+					"X-Header": "value_from_env",
+				},
+			},
+			errString: "",
+			remoteConfig: &remote.ClientConfig{
+				URL:     &promConfig.URL{URL: u},
+				Timeout: model.Duration(defaultPrometheusTimeout),
+				HTTPClientConfig: promConfig.HTTPClientConfig{
+					FollowRedirects: true,
+					TLSConfig: promConfig.TLSConfig{
+						InsecureSkipVerify: false,
+					},
+				},
+				RetryOnRateLimit: false,
+				Headers: map[string]string{
+					"X-Header": "value_from_env",
+				},
+			},
+		},
+		"remote_write_with_headers_arg": {
+			jsonRaw: json.RawMessage(fmt.Sprintf(`{"url":"%s","mapping":"mapping", "headers":{"X-Header":"value"}}`, u.String())),
+			env: map[string]string{
+				"K6_PROMETHEUS_HEADERS_X-Header": "value_from_env",
+			},
+			arg: "headers.X-Header=value_from_arg",
+			config: Config{
+				Mapping:               null.NewString("mapping", true),
+				Url:                   null.StringFrom(u.String()),
+				InsecureSkipTLSVerify: null.BoolFrom(true),
+				CACert:                null.NewString("", false),
+				User:                  null.NewString("", false),
+				Password:              null.NewString("", false),
+				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
+				KeepTags:              null.BoolFrom(true),
+				KeepNameTag:           null.BoolFrom(false),
+				Headers: map[string]string{
+					"X-Header": "value_from_arg",
+				},
+			},
+			errString: "",
+			remoteConfig: &remote.ClientConfig{
+				URL:     &promConfig.URL{URL: u},
+				Timeout: model.Duration(defaultPrometheusTimeout),
+				HTTPClientConfig: promConfig.HTTPClientConfig{
+					FollowRedirects: true,
+					TLSConfig: promConfig.TLSConfig{
+						InsecureSkipVerify: false,
+					},
+				},
+				RetryOnRateLimit: false,
+				Headers: map[string]string{
+					"X-Header": "value_from_arg",
 				},
 			},
 		},


### PR DESCRIPTION
Add support for http headers so that  it can use cortex with the `auth_enabled` option


Signed-off-by: johncming <johncming@yahoo.com>