### PR TITLE
Add support for keepUrlTag

### DIFF
--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -38,6 +38,7 @@ type Config struct {
 
 	KeepTags    null.Bool `json:"keepTags" envconfig:"K6_KEEP_TAGS"`
 	KeepNameTag null.Bool `json:"keepNameTag" envconfig:"K6_KEEP_NAME_TAG"`
+	KeepUrlTag  null.Bool `json:"keepUrlTag" envconfig:"K6_KEEP_URL_TAG"`
 }
 
 func NewConfig() Config {
@@ -51,6 +52,7 @@ func NewConfig() Config {
 		FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
 		KeepTags:              null.BoolFrom(true),
 		KeepNameTag:           null.BoolFrom(false),
+		KeepUrlTag:            null.BoolFrom(true),
 		Headers:               make(map[string]string),
 	}
 }
@@ -131,6 +133,10 @@ func (base Config) Apply(applied Config) Config {
 		base.KeepNameTag = applied.KeepNameTag
 	}
 
+	if applied.KeepUrlTag.Valid {
+		base.KeepUrlTag = applied.KeepUrlTag
+	}
+
 	if len(applied.Headers) > 0 {
 		for k, v := range applied.Headers {
 			base.Headers[k] = v
@@ -184,6 +190,10 @@ func ParseArg(arg string) (Config, error) {
 
 	if v, ok := params["keepNameTag"].(bool); ok {
 		c.KeepNameTag = null.BoolFrom(v)
+	}
+
+	if v, ok := params["keepUrlTag"].(bool); ok {
+		c.KeepUrlTag = null.BoolFrom(v)
 	}
 
 	c.Headers = make(map[string]string)
@@ -281,6 +291,14 @@ func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, a
 	} else {
 		if b.Valid {
 			result.KeepNameTag = b
+		}
+	}
+
+	if b, err := getEnvBool(env, "K6_KEEP_URL_TAG"); err != nil {
+		return result, err
+	} else {
+		if b.Valid {
+			result.KeepUrlTag = b
 		}
 	}
 

--- a/pkg/remotewrite/config_test.go
+++ b/pkg/remotewrite/config_test.go
@@ -117,6 +117,7 @@ func TestConstructRemoteConfig(t *testing.T) {
 				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
 				KeepTags:              null.BoolFrom(true),
 				KeepNameTag:           null.BoolFrom(false),
+				KeepUrlTag:            null.BoolFrom(true),
 				Headers:               make(map[string]string),
 			},
 			errString: "",
@@ -146,6 +147,7 @@ func TestConstructRemoteConfig(t *testing.T) {
 				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
 				KeepTags:              null.BoolFrom(true),
 				KeepNameTag:           null.BoolFrom(false),
+				KeepUrlTag:            null.BoolFrom(true),
 				Headers:               make(map[string]string),
 			},
 			errString: "",
@@ -194,6 +196,7 @@ func TestConstructRemoteConfig(t *testing.T) {
 				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
 				KeepTags:              null.BoolFrom(true),
 				KeepNameTag:           null.BoolFrom(false),
+				KeepUrlTag:            null.BoolFrom(true),
 				Headers: map[string]string{
 					"X-Header": "value",
 				},
@@ -230,6 +233,7 @@ func TestConstructRemoteConfig(t *testing.T) {
 				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
 				KeepTags:              null.BoolFrom(true),
 				KeepNameTag:           null.BoolFrom(false),
+				KeepUrlTag:            null.BoolFrom(true),
 				Headers: map[string]string{
 					"X-Header": "value_from_env",
 				},
@@ -266,6 +270,7 @@ func TestConstructRemoteConfig(t *testing.T) {
 				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
 				KeepTags:              null.BoolFrom(true),
 				KeepNameTag:           null.BoolFrom(false),
+				KeepUrlTag:            null.BoolFrom(true),
 				Headers: map[string]string{
 					"X-Header": "value_from_arg",
 				},
@@ -315,6 +320,7 @@ func assertConfig(t *testing.T, actual, expected Config) {
 	assert.Equal(t, expected.FlushPeriod, actual.FlushPeriod)
 	assert.Equal(t, expected.KeepTags, actual.KeepTags)
 	assert.Equal(t, expected.KeepNameTag, expected.KeepNameTag)
+	assert.Equal(t, expected.KeepUrlTag, expected.KeepUrlTag)
 	assert.Equal(t, expected.Headers, actual.Headers)
 }
 

--- a/pkg/remotewrite/labels.go
+++ b/pkg/remotewrite/labels.go
@@ -22,6 +22,10 @@ func tagsToLabels(tags *stats.SampleTags, config Config) ([]prompb.Label, error)
 			continue
 		}
 
+		if !config.KeepUrlTag.Bool && name == "url" {
+			continue
+		}
+
 		labelPairs = append(labelPairs, prompb.Label{
 			Name:  name,
 			Value: value,

--- a/pkg/remotewrite/labels_test.go
+++ b/pkg/remotewrite/labels_test.go
@@ -48,6 +48,27 @@ func TestTagsToLabels(t *testing.T) {
 				{Name: "name", Value: "nnn"},
 			},
 		},
+		"url-tag-discard": {
+			tags: stats.NewSampleTags(map[string]string{"foo": "bar", "url": "uuu"}),
+			config: Config{
+				KeepTags:   null.BoolFrom(true),
+				KeepUrlTag: null.BoolFrom(false),
+			},
+			labels: []prompb.Label{
+				{Name: "foo", Value: "bar"},
+			},
+		},
+		"url-tag-keep": {
+			tags: stats.NewSampleTags(map[string]string{"foo": "bar", "url": "uuu"}),
+			config: Config{
+				KeepTags:   null.BoolFrom(true),
+				KeepUrlTag: null.BoolFrom(true),
+			},
+			labels: []prompb.Label{
+				{Name: "foo", Value: "bar"},
+				{Name: "url", Value: "uuu"},
+			},
+		},
 		"discard-tags": {
 			tags: stats.NewSampleTags(map[string]string{"foo": "bar", "name": "nnn"}),
 			config: Config{


### PR DESCRIPTION
Since the URL tag can often have high cardinality this PR makes this Tag/Label optional following the same structure as the keepNameTag config setting. Default `true` for backwards compatibility.

This allows for a common URL Grouping pattern to be used as describe [here](https://k6.io/docs/using-k6/http-requests/#url-grouping) by setting ` K6_KEEP_URL_TAG=false` and `K6_KEEP_NAME_TAG=true`

Tests also added with the same format as name tag handling