### PR TITLE
Polish config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ K6_PROMETHEUS_REMOTE_URL=http://localhost:9090/api/v1/write ./k6 run script.js -
 
 Add TLS and HTTP basic authentication:
 ```
-K6_PROMETHEUS_REMOTE_URL=https://localhost:9090/api/v1/write K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY=false K6_CA_CERT_FILE=example/tls.crt K6_PROMETHEUS_USER=foo K6_PROMETHEUS_PASSWORD=bar ./k6 run script.js -o output-prometheus-remote
+K6_PROMETHEUS_REMOTE_URL=https://localhost:9090/api/v1/write \
+K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY=false \
+K6_PROMETHEUS_USERNAME=foo \
+K6_PROMETHEUS_PASSWORD=bar \
+./k6 run script.js -o output-prometheus-remote
 ```
 
 Note: Prometheus remote client relies on a snappy library for serialization which could panic on [encode operations](https://github.com/golang/snappy/blob/544b4180ac705b7605231d4a4550a1acb22a19fe/encode.go#L22).

--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -16,43 +16,31 @@ import (
 )
 
 const (
+	defaultURL               = "http://localhost:9090/api/v1/write"
 	defaultPrometheusTimeout = time.Minute
-	defaultFlushPeriod       = 5 * time.Second
+	defaultPushInterval      = 5 * time.Second
 	defaultMetricPrefix      = "k6_"
 )
 
 type Config struct {
-	Mapping null.String `json:"mapping" envconfig:"K6_PROMETHEUS_MAPPING"`
-
-	Url null.String `json:"url" envconfig:"K6_PROMETHEUS_REMOTE_URL"` // here, in the name of env variable, we assume that we won't need to distinguish between remote write URL vs remote read URL
-
+	// here, in the name of env variable, we assume that we won't need to distinguish between remote write URL vs remote read URL
+	URL     null.String       `json:"url" envconfig:"K6_PROMETHEUS_REMOTE_URL"`
 	Headers map[string]string `json:"headers" envconfig:"K6_PROMETHEUS_HEADERS"`
 
 	InsecureSkipTLSVerify null.Bool   `json:"insecureSkipTLSVerify" envconfig:"K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY"`
-	CACert                null.String `json:"caCertFile" envconfig:"K6_CA_CERT_FILE"`
+	Username              null.String `json:"username" envconfig:"K6_PROMETHEUS_USERNAME"`
+	Password              null.String `json:"password" envconfig:"K6_PROMETHEUS_PASSWORD"`
 
-	User     null.String `json:"user" envconfig:"K6_PROMETHEUS_USER"`
-	Password null.String `json:"password" envconfig:"K6_PROMETHEUS_PASSWORD"`
-
-	FlushPeriod types.NullDuration `json:"flushPeriod" envconfig:"K6_PROMETHEUS_FLUSH_PERIOD"`
-
-	KeepTags    null.Bool `json:"keepTags" envconfig:"K6_KEEP_TAGS"`
-	KeepNameTag null.Bool `json:"keepNameTag" envconfig:"K6_KEEP_NAME_TAG"`
-	KeepUrlTag  null.Bool `json:"keepUrlTag" envconfig:"K6_KEEP_URL_TAG"`
+	PushInterval types.NullDuration `json:"pushInterval" envconfig:"K6_PROMETHEUS_PUSH_INTERVAL"`
 }
 
 func NewConfig() Config {
 	return Config{
-		Mapping:               null.StringFrom("prometheus"),
-		Url:                   null.StringFrom("http://localhost:9090/api/v1/write"),
+		URL:                   null.StringFrom(defaultURL),
 		InsecureSkipTLSVerify: null.BoolFrom(true),
-		CACert:                null.NewString("", false),
-		User:                  null.NewString("", false),
+		Username:              null.NewString("", false),
 		Password:              null.NewString("", false),
-		FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
-		KeepTags:              null.BoolFrom(true),
-		KeepNameTag:           null.BoolFrom(false),
-		KeepUrlTag:            null.BoolFrom(true),
+		PushInterval:          types.NullDurationFrom(defaultPushInterval),
 		Headers:               make(map[string]string),
 	}
 }
@@ -64,22 +52,17 @@ func (conf Config) ConstructRemoteConfig() (*remote.ClientConfig, error) {
 		InsecureSkipVerify: conf.InsecureSkipTLSVerify.Bool,
 	}
 
-	// if insecureSkipTLSVerify is switched off, use the certificate file
-	if !conf.InsecureSkipTLSVerify.Bool {
-		httpConfig.TLSConfig.CAFile = conf.CACert.String
-	}
-
 	// if at least valid user was configured, use basic auth
-	if conf.User.Valid {
+	if conf.Username.Valid {
 		httpConfig.BasicAuth = &promConfig.BasicAuth{
-			Username: conf.User.String,
+			Username: conf.Username.String,
 			Password: promConfig.Secret(conf.Password.String),
 		}
 	}
 	// TODO: consider if the auth logic should be enforced here
 	// (e.g. if insecureSkipTLSVerify is switched off, then check for non-empty certificate file and auth, etc.)
 
-	u, err := url.Parse(conf.Url.String)
+	u, err := url.Parse(conf.URL.String)
 	if err != nil {
 		return nil, err
 	}
@@ -97,44 +80,24 @@ func (conf Config) ConstructRemoteConfig() (*remote.ClientConfig, error) {
 // From here till the end of the file partial duplicates waiting for config refactor (k6 #883)
 
 func (base Config) Apply(applied Config) Config {
-	if applied.Mapping.Valid {
-		base.Mapping = applied.Mapping
-	}
-
-	if applied.Url.Valid {
-		base.Url = applied.Url
+	if applied.URL.Valid {
+		base.URL = applied.URL
 	}
 
 	if applied.InsecureSkipTLSVerify.Valid {
 		base.InsecureSkipTLSVerify = applied.InsecureSkipTLSVerify
 	}
 
-	if applied.CACert.Valid {
-		base.CACert = applied.CACert
-	}
-
-	if applied.User.Valid {
-		base.User = applied.User
+	if applied.Username.Valid {
+		base.Username = applied.Username
 	}
 
 	if applied.Password.Valid {
 		base.Password = applied.Password
 	}
 
-	if applied.FlushPeriod.Valid {
-		base.FlushPeriod = applied.FlushPeriod
-	}
-
-	if applied.KeepTags.Valid {
-		base.KeepTags = applied.KeepTags
-	}
-
-	if applied.KeepNameTag.Valid {
-		base.KeepNameTag = applied.KeepNameTag
-	}
-
-	if applied.KeepUrlTag.Valid {
-		base.KeepUrlTag = applied.KeepUrlTag
+	if applied.PushInterval.Valid {
+		base.PushInterval = applied.PushInterval
 	}
 
 	if len(applied.Headers) > 0 {
@@ -154,46 +117,26 @@ func ParseArg(arg string) (Config, error) {
 		return c, err
 	}
 
-	if v, ok := params["mapping"].(string); ok {
-		c.Mapping = null.StringFrom(v)
-	}
-
 	if v, ok := params["url"].(string); ok {
-		c.Url = null.StringFrom(v)
+		c.URL = null.StringFrom(v)
 	}
 
 	if v, ok := params["insecureSkipTLSVerify"].(bool); ok {
 		c.InsecureSkipTLSVerify = null.BoolFrom(v)
 	}
 
-	if v, ok := params["caCertFile"].(string); ok {
-		c.CACert = null.StringFrom(v)
-	}
-
 	if v, ok := params["user"].(string); ok {
-		c.User = null.StringFrom(v)
+		c.Username = null.StringFrom(v)
 	}
 
 	if v, ok := params["password"].(string); ok {
 		c.Password = null.StringFrom(v)
 	}
 
-	if v, ok := params["flushPeriod"].(string); ok {
-		if err := c.FlushPeriod.UnmarshalText([]byte(v)); err != nil {
+	if v, ok := params["pushInterval"].(string); ok {
+		if err := c.PushInterval.UnmarshalText([]byte(v)); err != nil {
 			return c, err
 		}
-	}
-
-	if v, ok := params["keepTags"].(bool); ok {
-		c.KeepTags = null.BoolFrom(v)
-	}
-
-	if v, ok := params["keepNameTag"].(bool); ok {
-		c.KeepNameTag = null.BoolFrom(v)
-	}
-
-	if v, ok := params["keepUrlTag"].(bool); ok {
-		c.KeepUrlTag = null.BoolFrom(v)
 	}
 
 	c.Headers = make(map[string]string)
@@ -243,18 +186,14 @@ func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, a
 	}
 
 	// envconfig is not processing some undefined vars (at least duration) so apply them manually
-	if flushPeriod, flushPeriodDefined := env["K6_PROMETHEUS_FLUSH_PERIOD"]; flushPeriodDefined {
-		if err := result.FlushPeriod.UnmarshalText([]byte(flushPeriod)); err != nil {
+	if pushInterval, pushIntervalDefined := env["K6_PROMETHEUS_PUSH_INTERVAL"]; pushIntervalDefined {
+		if err := result.PushInterval.UnmarshalText([]byte(pushInterval)); err != nil {
 			return result, err
 		}
 	}
 
-	if mapping, mappingDefined := env["K6_PROMETHEUS_MAPPING"]; mappingDefined {
-		result.Mapping = null.StringFrom(mapping)
-	}
-
 	if url, urlDefined := env["K6_PROMETHEUS_REMOTE_URL"]; urlDefined {
-		result.Url = null.StringFrom(url)
+		result.URL = null.StringFrom(url)
 	}
 
 	if b, err := getEnvBool(env, "K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY"); err != nil {
@@ -266,40 +205,12 @@ func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, a
 		}
 	}
 
-	if ca, caDefined := env["K6_CA_CERT_FILE"]; caDefined {
-		result.CACert = null.StringFrom(ca)
-	}
-
 	if user, userDefined := env["K6_PROMETHEUS_USER"]; userDefined {
-		result.User = null.StringFrom(user)
+		result.Username = null.StringFrom(user)
 	}
 
 	if password, passwordDefined := env["K6_PROMETHEUS_PASSWORD"]; passwordDefined {
 		result.Password = null.StringFrom(password)
-	}
-
-	if b, err := getEnvBool(env, "K6_KEEP_TAGS"); err != nil {
-		return result, err
-	} else {
-		if b.Valid {
-			result.KeepTags = b
-		}
-	}
-
-	if b, err := getEnvBool(env, "K6_KEEP_NAME_TAG"); err != nil {
-		return result, err
-	} else {
-		if b.Valid {
-			result.KeepNameTag = b
-		}
-	}
-
-	if b, err := getEnvBool(env, "K6_KEEP_URL_TAG"); err != nil {
-		return result, err
-	} else {
-		if b.Valid {
-			result.KeepUrlTag = b
-		}
 	}
 
 	envHeaders := getEnvMap(env, "K6_PROMETHEUS_HEADERS_")

--- a/pkg/remotewrite/config_test.go
+++ b/pkg/remotewrite/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/lib/types"
 	"gopkg.in/guregu/null.v3"
 )
@@ -19,12 +20,11 @@ func TestApply(t *testing.T) {
 	t.Parallel()
 
 	fullConfig := Config{
-		Url:                   null.StringFrom("some-url"),
+		URL:                   null.StringFrom("some-url"),
 		InsecureSkipTLSVerify: null.BoolFrom(false),
-		CACert:                null.StringFrom("some-file"),
-		User:                  null.StringFrom("user"),
+		Username:              null.StringFrom("user"),
 		Password:              null.StringFrom("pass"),
-		FlushPeriod:           types.NullDurationFrom(10 * time.Second),
+		PushInterval:          types.NullDurationFrom(10 * time.Second),
 		Headers: map[string]string{
 			"X-Header": "value",
 		},
@@ -33,22 +33,16 @@ func TestApply(t *testing.T) {
 	// Defaults should be overwritten by valid values
 	c := NewConfig()
 	c = c.Apply(fullConfig)
-	assert.Equal(t, fullConfig.Url, c.Url)
-	assert.Equal(t, fullConfig.InsecureSkipTLSVerify, c.InsecureSkipTLSVerify)
-	assert.Equal(t, fullConfig.CACert, c.CACert)
-	assert.Equal(t, fullConfig.User, c.User)
-	assert.Equal(t, fullConfig.Password, c.Password)
-	assert.Equal(t, fullConfig.FlushPeriod, c.FlushPeriod)
-	assert.Equal(t, fullConfig.Headers, c.Headers)
+	assert.Equal(t, fullConfig, c)
 
 	// Defaults shouldn't be impacted by invalid values
 	c = NewConfig()
 	c = c.Apply(Config{
-		User:                  null.NewString("user", false),
+		Username:              null.NewString("user", false),
 		Password:              null.NewString("pass", false),
 		InsecureSkipTLSVerify: null.NewBool(false, false),
 	})
-	assert.Equal(t, false, c.User.Valid)
+	assert.Equal(t, false, c.Username.Valid)
 	assert.Equal(t, false, c.Password.Valid)
 	assert.Equal(t, true, c.InsecureSkipTLSVerify.Valid)
 }
@@ -58,78 +52,109 @@ func TestConfigParseArg(t *testing.T) {
 
 	c, err := ParseArg("url=http://prometheus.remote:3412/write")
 	assert.Nil(t, err)
-	assert.Equal(t, null.StringFrom("http://prometheus.remote:3412/write"), c.Url)
+	assert.Equal(t, null.StringFrom("http://prometheus.remote:3412/write"), c.URL)
 
 	c, err = ParseArg("url=http://prometheus.remote:3412/write,insecureSkipTLSVerify=false")
 	assert.Nil(t, err)
-	assert.Equal(t, null.StringFrom("http://prometheus.remote:3412/write"), c.Url)
+	assert.Equal(t, null.StringFrom("http://prometheus.remote:3412/write"), c.URL)
 	assert.Equal(t, null.BoolFrom(false), c.InsecureSkipTLSVerify)
 
-	c, err = ParseArg("url=https://prometheus.remote:3412/write,caCertFile=f.crt")
+	c, err = ParseArg("url=https://prometheus.remote:3412/write")
 	assert.Nil(t, err)
-	assert.Equal(t, null.StringFrom("https://prometheus.remote:3412/write"), c.Url)
-	assert.Equal(t, null.StringFrom("f.crt"), c.CACert)
+	assert.Equal(t, null.StringFrom("https://prometheus.remote:3412/write"), c.URL)
 
-	c, err = ParseArg("url=https://prometheus.remote:3412/write,insecureSkipTLSVerify=false,caCertFile=f.crt,user=user,password=pass")
+	c, err = ParseArg("url=https://prometheus.remote:3412/write,insecureSkipTLSVerify=false,user=user,password=pass")
 	assert.Nil(t, err)
-	assert.Equal(t, null.StringFrom("https://prometheus.remote:3412/write"), c.Url)
+	assert.Equal(t, null.StringFrom("https://prometheus.remote:3412/write"), c.URL)
 	assert.Equal(t, null.BoolFrom(false), c.InsecureSkipTLSVerify)
-	assert.Equal(t, null.StringFrom("f.crt"), c.CACert)
-	assert.Equal(t, null.StringFrom("user"), c.User)
+	assert.Equal(t, null.StringFrom("user"), c.Username)
 	assert.Equal(t, null.StringFrom("pass"), c.Password)
 
-	c, err = ParseArg("url=http://prometheus.remote:3412/write,flushPeriod=2s")
+	c, err = ParseArg("url=http://prometheus.remote:3412/write,pushInterval=2s")
 	assert.Nil(t, err)
-	assert.Equal(t, null.StringFrom("http://prometheus.remote:3412/write"), c.Url)
-	assert.Equal(t, types.NullDurationFrom(time.Second*2), c.FlushPeriod)
+	assert.Equal(t, null.StringFrom("http://prometheus.remote:3412/write"), c.URL)
+	assert.Equal(t, types.NullDurationFrom(time.Second*2), c.PushInterval)
 
 	c, err = ParseArg("url=http://prometheus.remote:3412/write,headers.X-Header=value")
 	assert.Nil(t, err)
-	assert.Equal(t, null.StringFrom("http://prometheus.remote:3412/write"), c.Url)
+	assert.Equal(t, null.StringFrom("http://prometheus.remote:3412/write"), c.URL)
 	assert.Equal(t, map[string]string{"X-Header": "value"}, c.Headers)
 }
 
-// testing both GetConsolidatedConfig and ConstructRemoteConfig here until it's future config refactor takes shape (k6 #883)
 func TestConstructRemoteConfig(t *testing.T) {
-	u, _ := url.Parse("https://prometheus.ie/remote")
+	u, err := url.Parse("https://prometheus.ie/remote")
+	require.NoError(t, err)
 
+	config := Config{
+		URL:                   null.StringFrom(u.String()),
+		InsecureSkipTLSVerify: null.BoolFrom(true),
+		Username:              null.StringFrom("myuser"),
+		Password:              null.StringFrom("mypass"),
+		Headers: map[string]string{
+			"X-MYCUSTOM-HEADER": "val1",
+		},
+	}
+
+	exprcc := &remote.ClientConfig{
+		URL:     &promConfig.URL{URL: u},
+		Timeout: model.Duration(time.Minute),
+		HTTPClientConfig: promConfig.HTTPClientConfig{
+			FollowRedirects: true,
+			TLSConfig: promConfig.TLSConfig{
+				InsecureSkipVerify: true,
+			},
+			BasicAuth: &promConfig.BasicAuth{
+				Username: "myuser",
+				Password: "mypass",
+			},
+		},
+		RetryOnRateLimit: true,
+		Headers: map[string]string{
+			"X-MYCUSTOM-HEADER": "val1",
+		},
+	}
+	rcc, err := config.ConstructRemoteConfig()
+	require.NoError(t, err)
+	assert.Equal(t, exprcc, rcc)
+}
+
+func TestConifgConsolidation(t *testing.T) {
 	t.Parallel()
 
+	u, err := url.Parse("https://prometheus.ie/remote")
+	require.NoError(t, err)
+
 	testCases := map[string]struct {
-		jsonRaw      json.RawMessage
-		env          map[string]string
-		arg          string
-		config       Config
-		errString    string
-		remoteConfig *remote.ClientConfig
+		jsonRaw   json.RawMessage
+		env       map[string]string
+		arg       string
+		config    Config
+		errString string
 	}{
+		"default": {
+			jsonRaw: nil,
+			env:     nil,
+			arg:     "",
+			config: Config{
+				URL:                   null.StringFrom("http://localhost:9090/api/v1/write"),
+				InsecureSkipTLSVerify: null.BoolFrom(true),
+				Username:              null.NewString("", false),
+				Password:              null.NewString("", false),
+				PushInterval:          types.NullDurationFrom(5 * time.Second),
+				Headers:               make(map[string]string),
+			},
+		},
 		"json_success": {
 			jsonRaw: json.RawMessage(fmt.Sprintf(`{"url":"%s"}`, u.String())),
 			env:     nil,
 			arg:     "",
 			config: Config{
-				Url:                   null.StringFrom(u.String()),
+				URL:                   null.StringFrom(u.String()),
 				InsecureSkipTLSVerify: null.BoolFrom(true),
-				CACert:                null.NewString("", false),
-				User:                  null.NewString("", false),
+				Username:              null.NewString("", false),
 				Password:              null.NewString("", false),
-				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
-				KeepTags:              null.BoolFrom(true),
-				KeepNameTag:           null.BoolFrom(false),
-				KeepUrlTag:            null.BoolFrom(true),
+				PushInterval:          types.NullDurationFrom(defaultPushInterval),
 				Headers:               make(map[string]string),
-			},
-			errString: "",
-			remoteConfig: &remote.ClientConfig{
-				URL:     &promConfig.URL{URL: u},
-				Timeout: model.Duration(defaultPrometheusTimeout),
-				HTTPClientConfig: promConfig.HTTPClientConfig{
-					FollowRedirects: true,
-					TLSConfig: promConfig.TLSConfig{
-						InsecureSkipVerify: true,
-					},
-				},
-				RetryOnRateLimit: false,
 			},
 		},
 		"mixed_success": {
@@ -137,82 +162,44 @@ func TestConstructRemoteConfig(t *testing.T) {
 			env:     map[string]string{"K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY": "false", "K6_PROMETHEUS_USER": "u"},
 			arg:     "user=user",
 			config: Config{
-				Url:                   null.StringFrom(u.String()),
+				URL:                   null.StringFrom(u.String()),
 				InsecureSkipTLSVerify: null.BoolFrom(false),
-				CACert:                null.NewString("", false),
-				User:                  null.NewString("user", true),
+				Username:              null.NewString("user", true),
 				Password:              null.NewString("", false),
-				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
-				KeepTags:              null.BoolFrom(true),
-				KeepNameTag:           null.BoolFrom(false),
-				KeepUrlTag:            null.BoolFrom(true),
+				PushInterval:          types.NullDurationFrom(defaultPushInterval),
 				Headers:               make(map[string]string),
 			},
 			errString: "",
-			remoteConfig: &remote.ClientConfig{
-				URL:     &promConfig.URL{URL: u},
-				Timeout: model.Duration(defaultPrometheusTimeout),
-				HTTPClientConfig: promConfig.HTTPClientConfig{
-					FollowRedirects: true,
-					TLSConfig: promConfig.TLSConfig{
-						InsecureSkipVerify: false,
-					},
-					BasicAuth: &promConfig.BasicAuth{
-						Username: "user",
-					},
-				},
-				RetryOnRateLimit: false,
-			},
 		},
 		"invalid_duration": {
-			jsonRaw:      json.RawMessage(fmt.Sprintf(`{"url":"%s"}`, u.String())),
-			env:          map[string]string{"K6_PROMETHEUS_FLUSH_PERIOD": "d"},
-			arg:          "",
-			config:       Config{},
-			errString:    "strconv.ParseInt",
-			remoteConfig: nil,
+			jsonRaw:   json.RawMessage(fmt.Sprintf(`{"url":"%s"}`, u.String())),
+			env:       map[string]string{"K6_PROMETHEUS_PUSH_INTERVAL": "d"},
+			arg:       "",
+			config:    Config{},
+			errString: "strconv.ParseInt",
 		},
 		"invalid_insecureSkipTLSVerify": {
-			jsonRaw:      json.RawMessage(fmt.Sprintf(`{"url":"%s"}`, u.String())),
-			env:          map[string]string{"K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY": "d"},
-			arg:          "",
-			config:       Config{},
-			errString:    "strconv.ParseBool",
-			remoteConfig: nil,
+			jsonRaw:   json.RawMessage(fmt.Sprintf(`{"url":"%s"}`, u.String())),
+			env:       map[string]string{"K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY": "d"},
+			arg:       "",
+			config:    Config{},
+			errString: "strconv.ParseBool",
 		},
 		"remote_write_with_headers_json": {
 			jsonRaw: json.RawMessage(fmt.Sprintf(`{"url":"%s","mapping":"mapping", "headers":{"X-Header":"value"}}`, u.String())),
 			env:     nil,
 			arg:     "",
 			config: Config{
-				Url:                   null.StringFrom(u.String()),
+				URL:                   null.StringFrom(u.String()),
 				InsecureSkipTLSVerify: null.BoolFrom(true),
-				CACert:                null.NewString("", false),
-				User:                  null.NewString("", false),
+				Username:              null.NewString("", false),
 				Password:              null.NewString("", false),
-				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
-				KeepTags:              null.BoolFrom(true),
-				KeepNameTag:           null.BoolFrom(false),
-				KeepUrlTag:            null.BoolFrom(true),
+				PushInterval:          types.NullDurationFrom(defaultPushInterval),
 				Headers: map[string]string{
 					"X-Header": "value",
 				},
 			},
 			errString: "",
-			remoteConfig: &remote.ClientConfig{
-				URL:     &promConfig.URL{URL: u},
-				Timeout: model.Duration(defaultPrometheusTimeout),
-				HTTPClientConfig: promConfig.HTTPClientConfig{
-					FollowRedirects: true,
-					TLSConfig: promConfig.TLSConfig{
-						InsecureSkipVerify: false,
-					},
-				},
-				RetryOnRateLimit: false,
-				Headers: map[string]string{
-					"X-Header": "value",
-				},
-			},
 		},
 		"remote_write_with_headers_env": {
 			jsonRaw: json.RawMessage(fmt.Sprintf(`{"url":"%s","mapping":"mapping", "headers":{"X-Header":"value"}}`, u.String())),
@@ -221,34 +208,16 @@ func TestConstructRemoteConfig(t *testing.T) {
 			},
 			arg: "",
 			config: Config{
-				Url:                   null.StringFrom(u.String()),
+				URL:                   null.StringFrom(u.String()),
 				InsecureSkipTLSVerify: null.BoolFrom(true),
-				CACert:                null.NewString("", false),
-				User:                  null.NewString("", false),
+				Username:              null.NewString("", false),
 				Password:              null.NewString("", false),
-				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
-				KeepTags:              null.BoolFrom(true),
-				KeepNameTag:           null.BoolFrom(false),
-				KeepUrlTag:            null.BoolFrom(true),
+				PushInterval:          types.NullDurationFrom(defaultPushInterval),
 				Headers: map[string]string{
 					"X-Header": "value_from_env",
 				},
 			},
 			errString: "",
-			remoteConfig: &remote.ClientConfig{
-				URL:     &promConfig.URL{URL: u},
-				Timeout: model.Duration(defaultPrometheusTimeout),
-				HTTPClientConfig: promConfig.HTTPClientConfig{
-					FollowRedirects: true,
-					TLSConfig: promConfig.TLSConfig{
-						InsecureSkipVerify: false,
-					},
-				},
-				RetryOnRateLimit: false,
-				Headers: map[string]string{
-					"X-Header": "value_from_env",
-				},
-			},
 		},
 		"remote_write_with_headers_arg": {
 			jsonRaw: json.RawMessage(fmt.Sprintf(`{"url":"%s","mapping":"mapping", "headers":{"X-Header":"value"}}`, u.String())),
@@ -257,34 +226,16 @@ func TestConstructRemoteConfig(t *testing.T) {
 			},
 			arg: "headers.X-Header=value_from_arg",
 			config: Config{
-				Url:                   null.StringFrom(u.String()),
+				URL:                   null.StringFrom(u.String()),
 				InsecureSkipTLSVerify: null.BoolFrom(true),
-				CACert:                null.NewString("", false),
-				User:                  null.NewString("", false),
+				Username:              null.NewString("", false),
 				Password:              null.NewString("", false),
-				FlushPeriod:           types.NullDurationFrom(defaultFlushPeriod),
-				KeepTags:              null.BoolFrom(true),
-				KeepNameTag:           null.BoolFrom(false),
-				KeepUrlTag:            null.BoolFrom(true),
+				PushInterval:          types.NullDurationFrom(defaultPushInterval),
 				Headers: map[string]string{
 					"X-Header": "value_from_arg",
 				},
 			},
 			errString: "",
-			remoteConfig: &remote.ClientConfig{
-				URL:     &promConfig.URL{URL: u},
-				Timeout: model.Duration(defaultPrometheusTimeout),
-				HTTPClientConfig: promConfig.HTTPClientConfig{
-					FollowRedirects: true,
-					TLSConfig: promConfig.TLSConfig{
-						InsecureSkipVerify: false,
-					},
-				},
-				RetryOnRateLimit: false,
-				Headers: map[string]string{
-					"X-Header": "value_from_arg",
-				},
-			},
 		},
 	}
 
@@ -293,39 +244,11 @@ func TestConstructRemoteConfig(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			c, err := GetConsolidatedConfig(testCase.jsonRaw, testCase.env, testCase.arg)
 			if len(testCase.errString) > 0 {
+				require.NotNil(t, err)
 				assert.Contains(t, err.Error(), testCase.errString)
 				return
 			}
-			assertConfig(t, c, testCase.config)
-
-			// there can be error only on url.Parse at the moment so skipping that
-			remoteConfig, _ := c.ConstructRemoteConfig()
-			assertRemoteConfig(t, remoteConfig, testCase.remoteConfig)
+			assert.Equal(t, c, testCase.config)
 		})
-	}
-}
-
-func assertConfig(t *testing.T, actual, expected Config) {
-	assert.Equal(t, expected.Url, actual.Url)
-	assert.Equal(t, expected.InsecureSkipTLSVerify, actual.InsecureSkipTLSVerify)
-	assert.Equal(t, expected.CACert, actual.CACert)
-	assert.Equal(t, expected.User, actual.User)
-	assert.Equal(t, expected.Password, actual.Password)
-	assert.Equal(t, expected.FlushPeriod, actual.FlushPeriod)
-	assert.Equal(t, expected.KeepTags, actual.KeepTags)
-	assert.Equal(t, expected.KeepNameTag, expected.KeepNameTag)
-	assert.Equal(t, expected.KeepUrlTag, expected.KeepUrlTag)
-	assert.Equal(t, expected.Headers, actual.Headers)
-}
-
-func assertRemoteConfig(t *testing.T, actual, expected *remote.ClientConfig) {
-	assert.Equal(t, expected.URL, actual.URL)
-	assert.Equal(t, expected.Timeout, actual.Timeout)
-	assert.Equal(t, expected.HTTPClientConfig.TLSConfig.CAFile, actual.HTTPClientConfig.TLSConfig.CAFile)
-	if expected.HTTPClientConfig.BasicAuth == nil {
-		assert.Nil(t, actual.HTTPClientConfig.BasicAuth)
-	} else {
-		assert.Equal(t, expected.HTTPClientConfig.BasicAuth.Username, actual.HTTPClientConfig.BasicAuth.Username)
-		assert.Equal(t, expected.HTTPClientConfig.BasicAuth.Password, actual.HTTPClientConfig.BasicAuth.Password)
 	}
 }

--- a/pkg/remotewrite/remotewrite.go
+++ b/pkg/remotewrite/remotewrite.go
@@ -63,7 +63,7 @@ func (*Output) Description() string {
 }
 
 func (o *Output) Start() error {
-	d := o.config.FlushPeriod.TimeDuration()
+	d := o.config.PushInterval.TimeDuration()
 	periodicFlusher, err := output.NewPeriodicFlusher(d, o.flush)
 	if err != nil {
 		return err
@@ -89,11 +89,11 @@ func (o *Output) flush() {
 	defer func() {
 		d := time.Since(start)
 		okmsg := "Successful flushed time series to remote write endpoint"
-		if d > time.Duration(o.config.FlushPeriod.Duration) {
+		if d > time.Duration(o.config.PushInterval.Duration) {
 			// There is no intermediary storage so warn if writing to remote write endpoint becomes too slow
 			o.logger.WithField("nts", nts).
 				Warnf("%s but it took %s while flush period is %s. Some samples may be dropped.",
-					okmsg, d.String(), o.config.FlushPeriod.String())
+					okmsg, d.String(), o.config.PushInterval.String())
 		} else {
 			o.logger.WithField("nts", nts).WithField("took", d).Debug(okmsg)
 		}

--- a/pkg/remotewrite/remotewrite.go
+++ b/pkg/remotewrite/remotewrite.go
@@ -58,8 +58,8 @@ func New(params output.Params) (*Output, error) {
 	}, nil
 }
 
-func (*Output) Description() string {
-	return "Prometheus remote write"
+func (o *Output) Description() string {
+	return fmt.Sprintf("Prometheus remote write (%s)", o.config.URL.String)
 }
 
 func (o *Output) Start() error {

--- a/pkg/remotewrite/remotewrite_test.go
+++ b/pkg/remotewrite/remotewrite_test.go
@@ -9,7 +9,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/metrics"
+	"gopkg.in/guregu/null.v3"
 )
+
+func TestOutputDescription(t *testing.T) {
+	t.Parallel()
+	o := Output{
+		config: Config{
+			URL: null.StringFrom("http://remote-url.fake"),
+		},
+	}
+	exp := "Prometheus remote write (http://remote-url.fake)"
+	assert.Equal(t, exp, o.Description())
+}
 
 func TestOutputConvertToPbSeries(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This PR includes changes for the config and the URL printing in the description.

Renamed for consistency the following env var options:

`K6_PROMETHEUS_FLUSH_PERIOD` => `K6_PROMETHEUS_PUSH_INTERVAL` (it aligns to the same name used by timescaledb, influxdb and statsd outputs).

`K6_PROMETHEUS_USER` => `K6_PROMETHEUS_USERNAME` (it aligns to the same name used by influxdb output).

Removed completely for aligning to what we are doing with other outputs the following options:

`KeepTags`, `KeepNameTag`, `KeepUrlTag`, as explained in https://github.com/grafana/xk6-output-prometheus-remote/issues/47, tags should be controlled by `systemTags` option or by the solution explained in https://github.com/grafana/xk6-output-prometheus-remote/issues/5 (TLDR; https://github.com/grafana/k6/issues/1321) when we will have implemented it.

Removed `Mapping` option because at the moment the output does not support different kinds of mappings so it does not make sense to export an option.

[The documentation](https://k6.io/docs/results-output/real-time/prometheus/#options) must be aligned when we will have merged this PR.


