### PR TITLE
Force the naming convention

### DIFF
--- a/pkg/remotewrite/remotewrite.go
+++ b/pkg/remotewrite/remotewrite.go
@@ -253,11 +253,9 @@ type seriesWithMeasure struct {
 func (swm seriesWithMeasure) MapPrompb() []*prompb.TimeSeries {
 	var newts []*prompb.TimeSeries
 
-	mapMonoSeries := func(s metrics.TimeSeries, t time.Time) prompb.TimeSeries {
+	mapMonoSeries := func(s metrics.TimeSeries, suffix string, t time.Time) prompb.TimeSeries {
 		return prompb.TimeSeries{
-			// TODO: should we add the suffix for
-			// Counter, Rate and Gauge?
-			Labels: MapSeries(s, ""),
+			Labels: MapSeries(s, suffix),
 			Samples: []*prompb.Sample{
 				{Timestamp: t.UnixMilli()},
 			},
@@ -266,17 +264,17 @@ func (swm seriesWithMeasure) MapPrompb() []*prompb.TimeSeries {
 
 	switch swm.Metric.Type {
 	case metrics.Counter:
-		ts := mapMonoSeries(swm.TimeSeries, swm.Latest)
+		ts := mapMonoSeries(swm.TimeSeries, "total", swm.Latest)
 		ts.Samples[0].Value = swm.Measure.(*metrics.CounterSink).Value
 		newts = []*prompb.TimeSeries{&ts}
 
 	case metrics.Gauge:
-		ts := mapMonoSeries(swm.TimeSeries, swm.Latest)
+		ts := mapMonoSeries(swm.TimeSeries, "", swm.Latest)
 		ts.Samples[0].Value = swm.Measure.(*metrics.GaugeSink).Value
 		newts = []*prompb.TimeSeries{&ts}
 
 	case metrics.Rate:
-		ts := mapMonoSeries(swm.TimeSeries, swm.Latest)
+		ts := mapMonoSeries(swm.TimeSeries, "rate", swm.Latest)
 		// pass zero duration here because time is useless for formatting rate
 		rateVals := swm.Measure.(*metrics.RateSink).Format(time.Duration(0))
 		ts.Samples[0].Value = rateVals["rate"]

--- a/pkg/remotewrite/remotewrite_test.go
+++ b/pkg/remotewrite/remotewrite_test.go
@@ -55,6 +55,14 @@ func TestOutputConvertToPbSeries(t *testing.T) {
 			Time:  time.Date(2022, time.September, 1, 0, 0, 0, 0, time.UTC),
 			Value: 2,
 		},
+		metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: registry.MustNewMetric("metric3", metrics.Rate),
+				Tags:   tagset,
+			},
+			Time:  time.Date(2022, time.September, 1, 0, 0, 0, 0, time.UTC),
+			Value: 7,
+		},
 	}
 
 	o := Output{
@@ -62,14 +70,14 @@ func TestOutputConvertToPbSeries(t *testing.T) {
 	}
 
 	pbseries := o.convertToPbSeries(samples)
-	require.Len(t, pbseries, 2)
-	require.Len(t, o.tsdb, 2)
+	require.Len(t, pbseries, 3)
+	require.Len(t, o.tsdb, 3)
 
 	unix1sept := int64(1661990400 * 1000) // in ms
 	exp := []*prompb.TimeSeries{
 		{
 			Labels: []*prompb.Label{
-				{Name: "__name__", Value: "k6_metric1"},
+				{Name: "__name__", Value: "k6_metric1_total"},
 				{Name: "tagk1", Value: "tagv1"},
 			},
 			Samples: []*prompb.Sample{
@@ -78,11 +86,20 @@ func TestOutputConvertToPbSeries(t *testing.T) {
 		},
 		{
 			Labels: []*prompb.Label{
-				{Name: "__name__", Value: "k6_metric2"},
+				{Name: "__name__", Value: "k6_metric2_total"},
 				{Name: "tagk1", Value: "tagv1"},
 			},
 			Samples: []*prompb.Sample{
 				{Value: 2, Timestamp: unix1sept},
+			},
+		},
+		{
+			Labels: []*prompb.Label{
+				{Name: "__name__", Value: "k6_metric3_rate"},
+				{Name: "tagk1", Value: "tagv1"},
+			},
+			Samples: []*prompb.Sample{
+				{Value: 1, Timestamp: unix1sept},
 			},
 		},
 	}


### PR DESCRIPTION
https://prometheus.io/docs/practices/naming/#metric-names

* Force `_total` suffix for the Counter type as suggested by the Prometheus and  OpenMetrics conventions.
* Force `_rate` suffix for the Rate type so it can be identified easier because they are converted into Gauges.