### PR TITLE
Rename from prometheus-remote to prometheus-rw

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ xk6 build --with github.com/grafana/xk6-output-prometheus-remote@latest
 
 Then run new k6 binary with:
 ```
-K6_PROMETHEUS_REMOTE_URL=http://localhost:9090/api/v1/write ./k6 run script.js -o output-prometheus-remote
+K6_PROMETHEUS_RW_REMOTE_URL=http://localhost:9090/api/v1/write ./k6 run script.js -o output-prometheus-remote
 ```
 
 Add TLS and HTTP basic authentication:
 ```
-K6_PROMETHEUS_REMOTE_URL=https://localhost:9090/api/v1/write \
-K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY=false \
-K6_PROMETHEUS_USERNAME=foo \
-K6_PROMETHEUS_PASSWORD=bar \
+K6_PROMETHEUS_RW_REMOTE_URL=https://localhost:9090/api/v1/write \
+K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY=false \
+K6_PROMETHEUS_RW_USERNAME=foo \
+K6_PROMETHEUS_RW_PASSWORD=bar \
 ./k6 run script.js -o output-prometheus-remote
 ```
 
@@ -48,7 +48,7 @@ Mapping Trend by Gauges has the following cons:
 * It is impossible to aggregate some Gauge's value (especially the percentiles).
 * It uses a memory-expensive k6's data structure.
 
-The previous points can be resolved by mapping Trend as [Prometheus Native Histogram](https://prometheus.io/docs/concepts/metric_types/#histogram). Enabling the conversion by the `K6_PROMETHEUS_TREND_AS_NATIVE_HISTOGRAM=true` environment variable (or one of the other ways), then the Output converts all the Trend types into a dedicated Native Histogram.
+The previous points can be resolved by mapping Trend as [Prometheus Native Histogram](https://prometheus.io/docs/concepts/metric_types/#histogram). Enabling the conversion by the `K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=true` environment variable (or one of the other ways), then the Output converts all the Trend types into a dedicated Native Histogram.
 
 Native Histogram is a Prometheus' experimental feature, so it has to be enabled (`--enable-feature=native-histograms`). Note that other Remote-write implementations don't support it yet.
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ xk6 build --with github.com/grafana/xk6-output-prometheus-remote@latest
 
 Then run new k6 binary with:
 ```
-K6_PROMETHEUS_RW_REMOTE_URL=http://localhost:9090/api/v1/write ./k6 run script.js -o output-prometheus-remote
+K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write ./k6 run script.js -o output-prometheus-remote
 ```
 
 Add TLS and HTTP basic authentication:
 ```
-K6_PROMETHEUS_RW_REMOTE_URL=https://localhost:9090/api/v1/write \
+K6_PROMETHEUS_RW_SERVER_URL=https://localhost:9090/api/v1/write \
 K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY=false \
 K6_PROMETHEUS_RW_USERNAME=foo \
 K6_PROMETHEUS_RW_PASSWORD=bar \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,8 @@ services:
     ports:
       - "6565:6565"
     environment:
-      - K6_PROMETHEUS_REMOTE_URL=http://prometheus:9090/api/v1/write
-      - K6_PROMETHEUS_TREND_AS_NATIVE_HISTOGRAM=true
+      - K6_PROMETHEUS_RW_REMOTE_URL=http://prometheus:9090/api/v1/write
+      - K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=true
       - K6_OUT=output-prometheus-remote
     depends_on:
       - prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     ports:
       - "6565:6565"
     environment:
-      - K6_PROMETHEUS_RW_REMOTE_URL=http://prometheus:9090/api/v1/write
+      - K6_PROMETHEUS_RW_SERVER_URL=http://prometheus:9090/api/v1/write
       - K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=true
       - K6_OUT=output-prometheus-remote
     depends_on:

--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -25,32 +25,32 @@ var defaultTrendStats = []string{"p(99)"}
 
 type Config struct {
 	// URL contains the absolute URL for the Write endpoint where to flush the time series.
-	URL null.String `json:"url" envconfig:"K6_PROMETHEUS_REMOTE_URL"`
+	URL null.String `json:"url" envconfig:"K6_PROMETHEUS_RW_REMOTE_URL"`
 
 	// Headers contains additional headers that should be included in the HTTP requests.
-	Headers map[string]string `json:"headers" envconfig:"K6_PROMETHEUS_HEADERS"`
+	Headers map[string]string `json:"headers" envconfig:"K6_PROMETHEUS_RW_HEADERS"`
 
 	// InsecureSkipTLSVerify skips TLS client side checks.
-	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify" envconfig:"K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY"`
+	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify" envconfig:"K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY"`
 
 	// Username is the User for Basic Auth.
-	Username null.String `json:"username" envconfig:"K6_PROMETHEUS_USERNAME"`
+	Username null.String `json:"username" envconfig:"K6_PROMETHEUS_RW_USERNAME"`
 
 	// Password is the Password for the Basic Auth.
-	Password null.String `json:"password" envconfig:"K6_PROMETHEUS_PASSWORD"`
+	Password null.String `json:"password" envconfig:"K6_PROMETHEUS_RW_PASSWORD"`
 
 	// PushInterval defines the time between flushes. The Output will wait the set time
 	// before push a new set of time series to the endpoint.
-	PushInterval types.NullDuration `json:"pushInterval" envconfig:"K6_PROMETHEUS_PUSH_INTERVAL"`
+	PushInterval types.NullDuration `json:"pushInterval" envconfig:"K6_PROMETHEUS_RW_PUSH_INTERVAL"`
 
 	// TrendAsNativeHistogram defines if the mapping for metrics defined as Trend type
 	// should map to a Prometheus' Native Histogram.
-	TrendAsNativeHistogram null.Bool `json:"trendAsNativeHistogram" envconfig:"K6_PROMETHEUS_TREND_AS_NATIVE_HISTOGRAM"`
+	TrendAsNativeHistogram null.Bool `json:"trendAsNativeHistogram" envconfig:"K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM"`
 
 	// TrendStats defines the stats to flush for Trend metrics.
 	//
 	// TODO: should we support K6_SUMMARY_TREND_STATS?
-	TrendStats []string `json:"trendStats" envconfig:"K6_PROMETHEUS_TREND_STATS"`
+	TrendStats []string `json:"trendStats" envconfig:"K6_PROMETHEUS_RW_TREND_STATS"`
 }
 
 // NewConfig creates an Output's configuration.
@@ -194,17 +194,17 @@ func parseEnvs(env map[string]string) (Config, error) {
 	}
 
 	// envconfig is not processing some undefined vars (at least duration) so apply them manually
-	if pushInterval, pushIntervalDefined := env["K6_PROMETHEUS_PUSH_INTERVAL"]; pushIntervalDefined {
+	if pushInterval, pushIntervalDefined := env["K6_PROMETHEUS_RW_PUSH_INTERVAL"]; pushIntervalDefined {
 		if err := c.PushInterval.UnmarshalText([]byte(pushInterval)); err != nil {
 			return c, err
 		}
 	}
 
-	if url, urlDefined := env["K6_PROMETHEUS_REMOTE_URL"]; urlDefined {
+	if url, urlDefined := env["K6_PROMETHEUS_RW_REMOTE_URL"]; urlDefined {
 		c.URL = null.StringFrom(url)
 	}
 
-	if b, err := getEnvBool(env, "K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY"); err != nil {
+	if b, err := getEnvBool(env, "K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY"); err != nil {
 		return c, err
 	} else {
 		if b.Valid {
@@ -212,15 +212,15 @@ func parseEnvs(env map[string]string) (Config, error) {
 		}
 	}
 
-	if user, userDefined := env["K6_PROMETHEUS_USERNAME"]; userDefined {
+	if user, userDefined := env["K6_PROMETHEUS_RW_USERNAME"]; userDefined {
 		c.Username = null.StringFrom(user)
 	}
 
-	if password, passwordDefined := env["K6_PROMETHEUS_PASSWORD"]; passwordDefined {
+	if password, passwordDefined := env["K6_PROMETHEUS_RW_PASSWORD"]; passwordDefined {
 		c.Password = null.StringFrom(password)
 	}
 
-	envHeaders := getEnvMap(env, "K6_PROMETHEUS_HEADERS_")
+	envHeaders := getEnvMap(env, "K6_PROMETHEUS_RW_HEADERS_")
 	for k, v := range envHeaders {
 		if c.Headers == nil {
 			c.Headers = make(map[string]string)
@@ -228,7 +228,7 @@ func parseEnvs(env map[string]string) (Config, error) {
 		c.Headers[k] = v
 	}
 
-	if b, err := getEnvBool(env, "K6_PROMETHEUS_TREND_AS_NATIVE_HISTOGRAM"); err != nil {
+	if b, err := getEnvBool(env, "K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM"); err != nil {
 		return c, err
 	} else {
 		if b.Valid {
@@ -236,7 +236,7 @@ func parseEnvs(env map[string]string) (Config, error) {
 		}
 	}
 
-	if trendStats, trendStatsDefined := env["K6_PROMETHEUS_TREND_STATS"]; trendStatsDefined {
+	if trendStats, trendStatsDefined := env["K6_PROMETHEUS_RW_TREND_STATS"]; trendStatsDefined {
 		c.TrendStats = strings.Split(trendStats, ",")
 	}
 

--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -25,7 +25,7 @@ var defaultTrendStats = []string{"p(99)"}
 
 type Config struct {
 	// URL contains the absolute URL for the Write endpoint where to flush the time series.
-	URL null.String `json:"url" envconfig:"K6_PROMETHEUS_RW_REMOTE_URL"`
+	URL null.String `json:"url" envconfig:"K6_PROMETHEUS_RW_SERVER_URL"`
 
 	// Headers contains additional headers that should be included in the HTTP requests.
 	Headers map[string]string `json:"headers" envconfig:"K6_PROMETHEUS_RW_HEADERS"`
@@ -200,7 +200,7 @@ func parseEnvs(env map[string]string) (Config, error) {
 		}
 	}
 
-	if url, urlDefined := env["K6_PROMETHEUS_RW_REMOTE_URL"]; urlDefined {
+	if url, urlDefined := env["K6_PROMETHEUS_RW_SERVER_URL"]; urlDefined {
 		c.URL = null.StringFrom(url)
 	}
 

--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultURL          = "http://localhost:9090/api/v1/write"
+	defaultServerURL    = "http://localhost:9090/api/v1/write"
 	defaultTimeout      = 5 * time.Second
 	defaultPushInterval = 5 * time.Second
 	defaultMetricPrefix = "k6_"
@@ -24,8 +24,8 @@ const (
 var defaultTrendStats = []string{"p(99)"}
 
 type Config struct {
-	// URL contains the absolute URL for the Write endpoint where to flush the time series.
-	URL null.String `json:"url" envconfig:"K6_PROMETHEUS_RW_SERVER_URL"`
+	// ServerURL contains the absolute ServerURL for the Write endpoint where to flush the time series.
+	ServerURL null.String `json:"url" envconfig:"K6_PROMETHEUS_RW_SERVER_URL"`
 
 	// Headers contains additional headers that should be included in the HTTP requests.
 	Headers map[string]string `json:"headers" envconfig:"K6_PROMETHEUS_RW_HEADERS"`
@@ -56,7 +56,7 @@ type Config struct {
 // NewConfig creates an Output's configuration.
 func NewConfig() Config {
 	return Config{
-		URL:                   null.StringFrom(defaultURL),
+		ServerURL:             null.StringFrom(defaultServerURL),
 		InsecureSkipTLSVerify: null.BoolFrom(true),
 		Username:              null.NewString("", false),
 		Password:              null.NewString("", false),
@@ -95,8 +95,8 @@ func (conf Config) RemoteConfig() (*remote.HTTPConfig, error) {
 
 // Apply merges applied Config into base.
 func (base Config) Apply(applied Config) Config {
-	if applied.URL.Valid {
-		base.URL = applied.URL
+	if applied.ServerURL.Valid {
+		base.ServerURL = applied.ServerURL
 	}
 
 	if applied.InsecureSkipTLSVerify.Valid {
@@ -201,7 +201,7 @@ func parseEnvs(env map[string]string) (Config, error) {
 	}
 
 	if url, urlDefined := env["K6_PROMETHEUS_RW_SERVER_URL"]; urlDefined {
-		c.URL = null.StringFrom(url)
+		c.ServerURL = null.StringFrom(url)
 	}
 
 	if b, err := getEnvBool(env, "K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY"); err != nil {
@@ -250,7 +250,7 @@ func parseJSON(data json.RawMessage) (Config, error) {
 	return c, err
 }
 
-// parseURL parses the supplied string of arguments into a Config.
+// parseArg parses the supplied string of arguments into a Config.
 func parseArg(text string) (Config, error) {
 	var c Config
 	opts := strings.Split(text, ",")
@@ -263,7 +263,7 @@ func parseArg(text string) (Config, error) {
 		key, v := r[0], r[1]
 		switch key {
 		case "url":
-			c.URL = null.StringFrom(v)
+			c.ServerURL = null.StringFrom(v)
 		case "insecureSkipTLSVerify":
 			if err := c.InsecureSkipTLSVerify.UnmarshalText([]byte(v)); err != nil {
 				return c, fmt.Errorf("insecureSkipTLSVerify value must be true or false, not %q", v)

--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -25,32 +25,32 @@ var defaultTrendStats = []string{"p(99)"}
 
 type Config struct {
 	// ServerURL contains the absolute ServerURL for the Write endpoint where to flush the time series.
-	ServerURL null.String `json:"url" envconfig:"K6_PROMETHEUS_RW_SERVER_URL"`
+	ServerURL null.String `json:"url"`
 
 	// Headers contains additional headers that should be included in the HTTP requests.
-	Headers map[string]string `json:"headers" envconfig:"K6_PROMETHEUS_RW_HEADERS"`
+	Headers map[string]string `json:"headers"`
 
 	// InsecureSkipTLSVerify skips TLS client side checks.
-	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify" envconfig:"K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY"`
+	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify"`
 
 	// Username is the User for Basic Auth.
-	Username null.String `json:"username" envconfig:"K6_PROMETHEUS_RW_USERNAME"`
+	Username null.String `json:"username"`
 
 	// Password is the Password for the Basic Auth.
-	Password null.String `json:"password" envconfig:"K6_PROMETHEUS_RW_PASSWORD"`
+	Password null.String `json:"password"`
 
 	// PushInterval defines the time between flushes. The Output will wait the set time
 	// before push a new set of time series to the endpoint.
-	PushInterval types.NullDuration `json:"pushInterval" envconfig:"K6_PROMETHEUS_RW_PUSH_INTERVAL"`
+	PushInterval types.NullDuration `json:"pushInterval"`
 
 	// TrendAsNativeHistogram defines if the mapping for metrics defined as Trend type
 	// should map to a Prometheus' Native Histogram.
-	TrendAsNativeHistogram null.Bool `json:"trendAsNativeHistogram" envconfig:"K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM"`
+	TrendAsNativeHistogram null.Bool `json:"trendAsNativeHistogram"`
 
 	// TrendStats defines the stats to flush for Trend metrics.
 	//
 	// TODO: should we support K6_SUMMARY_TREND_STATS?
-	TrendStats []string `json:"trendStats" envconfig:"K6_PROMETHEUS_RW_TREND_STATS"`
+	TrendStats []string `json:"trendStats"`
 }
 
 // NewConfig creates an Output's configuration.
@@ -193,7 +193,6 @@ func parseEnvs(env map[string]string) (Config, error) {
 		return result
 	}
 
-	// envconfig is not processing some undefined vars (at least duration) so apply them manually
 	if pushInterval, pushIntervalDefined := env["K6_PROMETHEUS_RW_PUSH_INTERVAL"]; pushIntervalDefined {
 		if err := c.PushInterval.UnmarshalText([]byte(pushInterval)); err != nil {
 			return c, err

--- a/pkg/remotewrite/config_test.go
+++ b/pkg/remotewrite/config_test.go
@@ -208,7 +208,7 @@ func TestOptionURL(t *testing.T) {
 		jsonRaw json.RawMessage
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"url":"http://prometheus:9090/api/v1/write"}`)},
-		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_REMOTE_URL": "http://prometheus:9090/api/v1/write"}},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_SERVER_URL": "http://prometheus:9090/api/v1/write"}},
 		//"Arg":  {arg: "url=http://prometheus:9090/api/v1/write"},
 	}
 

--- a/pkg/remotewrite/config_test.go
+++ b/pkg/remotewrite/config_test.go
@@ -122,8 +122,8 @@ func TestGetConsolidatedConfig(t *testing.T) {
 		"MixedSuccess": {
 			jsonRaw: json.RawMessage(fmt.Sprintf(`{"url":"%s"}`, u.String())),
 			env: map[string]string{
-				"K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY": "false",
-				"K6_PROMETHEUS_USERNAME":                 "u",
+				"K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY": "false",
+				"K6_PROMETHEUS_RW_USERNAME":                 "u",
 			},
 			// arg: "username=user",
 			config: Config{
@@ -139,8 +139,8 @@ func TestGetConsolidatedConfig(t *testing.T) {
 		"OrderOfPrecedence": {
 			jsonRaw: json.RawMessage(`{"url":"http://json:9090","username":"json","password":"json"}`),
 			env: map[string]string{
-				"K6_PROMETHEUS_USERNAME": "env",
-				"K6_PROMETHEUS_PASSWORD": "env",
+				"K6_PROMETHEUS_RW_USERNAME": "env",
+				"K6_PROMETHEUS_RW_PASSWORD": "env",
 			},
 			// arg: "password=arg",
 			config: Config{
@@ -158,7 +158,7 @@ func TestGetConsolidatedConfig(t *testing.T) {
 			errString: "parse JSON options failed",
 		},
 		"InvalidEnv": {
-			env:       map[string]string{"K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY": "d"},
+			env:       map[string]string{"K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY": "d"},
 			errString: "parse environment variables options failed",
 		},
 		//"InvalidArg": {
@@ -208,7 +208,7 @@ func TestOptionURL(t *testing.T) {
 		jsonRaw json.RawMessage
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"url":"http://prometheus:9090/api/v1/write"}`)},
-		"Env":  {env: map[string]string{"K6_PROMETHEUS_REMOTE_URL": "http://prometheus:9090/api/v1/write"}},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_REMOTE_URL": "http://prometheus:9090/api/v1/write"}},
 		//"Arg":  {arg: "url=http://prometheus:9090/api/v1/write"},
 	}
 
@@ -241,7 +241,7 @@ func TestOptionHeaders(t *testing.T) {
 		jsonRaw json.RawMessage
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"headers":{"X-MY-HEADER1":"hval1","X-MY-HEADER2":"hval2"}}`)},
-		"Env":  {env: map[string]string{"K6_PROMETHEUS_HEADERS_X-MY-HEADER1": "hval1", "K6_PROMETHEUS_HEADERS_X-MY-HEADER2": "hval2"}},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_HEADERS_X-MY-HEADER1": "hval1", "K6_PROMETHEUS_RW_HEADERS_X-MY-HEADER2": "hval2"}},
 		//"Arg":  {arg: "headers.X-MY-HEADER1=hval1,headers.X-MY-HEADER2=hval2"},
 	}
 
@@ -275,7 +275,7 @@ func TestOptionInsecureSkipTLSVerify(t *testing.T) {
 		jsonRaw json.RawMessage
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"insecureSkipTLSVerify":false}`)},
-		"Env":  {env: map[string]string{"K6_PROMETHEUS_INSECURE_SKIP_TLS_VERIFY": "false"}},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY": "false"}},
 		//"Arg":  {arg: "insecureSkipTLSVerify=false"},
 	}
 
@@ -306,7 +306,7 @@ func TestOptionBasicAuth(t *testing.T) {
 		jsonRaw json.RawMessage
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"username":"user1","password":"pass1"}`)},
-		"Env":  {env: map[string]string{"K6_PROMETHEUS_USERNAME": "user1", "K6_PROMETHEUS_PASSWORD": "pass1"}},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_USERNAME": "user1", "K6_PROMETHEUS_RW_PASSWORD": "pass1"}},
 		//"Arg":  {arg: "username=user1,password=pass1"},
 	}
 
@@ -340,7 +340,7 @@ func TestOptionTrendAsNativeHistogram(t *testing.T) {
 		jsonRaw json.RawMessage
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"trendAsNativeHistogram":true}`)},
-		"Env":  {env: map[string]string{"K6_PROMETHEUS_TREND_AS_NATIVE_HISTOGRAM": "true"}},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM": "true"}},
 		//"Arg":  {arg: "trendAsNativeHistogram=true"},
 	}
 
@@ -375,7 +375,7 @@ func TestOptionPushInterval(t *testing.T) {
 		jsonRaw json.RawMessage
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"pushInterval":"1m2s"}`)},
-		"Env":  {env: map[string]string{"K6_PROMETHEUS_PUSH_INTERVAL": "1m2s"}},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_PUSH_INTERVAL": "1m2s"}},
 		//"Arg":  {arg: "pushInterval=1m2s"},
 	}
 
@@ -409,7 +409,7 @@ func TestConfigTrendStats(t *testing.T) {
 		jsonRaw json.RawMessage
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"trendStats":["max","p(95)"]}`)},
-		"Env":  {env: map[string]string{"K6_PROMETHEUS_TREND_STATS": "max,p(95)"}},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_TREND_STATS": "max,p(95)"}},
 		// TODO: support arg, check the comment in the code
 		//"Arg":  {arg: "trendStats=max,p(95)"},
 	}

--- a/pkg/remotewrite/config_test.go
+++ b/pkg/remotewrite/config_test.go
@@ -20,7 +20,7 @@ func TestConfigApply(t *testing.T) {
 	t.Parallel()
 
 	fullConfig := Config{
-		URL:                   null.StringFrom("some-url"),
+		ServerURL:             null.StringFrom("some-url"),
 		InsecureSkipTLSVerify: null.BoolFrom(false),
 		Username:              null.StringFrom("user"),
 		Password:              null.StringFrom("pass"),
@@ -53,7 +53,7 @@ func TestConfigRemoteConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	config := Config{
-		URL:                   null.StringFrom(u.String()),
+		ServerURL:             null.StringFrom(u.String()),
 		InsecureSkipTLSVerify: null.BoolFrom(true),
 		Username:              null.StringFrom("myuser"),
 		Password:              null.StringFrom("mypass"),
@@ -98,7 +98,7 @@ func TestGetConsolidatedConfig(t *testing.T) {
 			env:     nil,
 			arg:     "",
 			config: Config{
-				URL:                   null.StringFrom("http://localhost:9090/api/v1/write"),
+				ServerURL:             null.StringFrom("http://localhost:9090/api/v1/write"),
 				InsecureSkipTLSVerify: null.BoolFrom(true),
 				Username:              null.NewString("", false),
 				Password:              null.NewString("", false),
@@ -110,7 +110,7 @@ func TestGetConsolidatedConfig(t *testing.T) {
 		"JSONSuccess": {
 			jsonRaw: json.RawMessage(fmt.Sprintf(`{"url":"%s"}`, u.String())),
 			config: Config{
-				URL:                   null.StringFrom(u.String()),
+				ServerURL:             null.StringFrom(u.String()),
 				InsecureSkipTLSVerify: null.BoolFrom(true),
 				Username:              null.NewString("", false),
 				Password:              null.NewString("", false),
@@ -127,7 +127,7 @@ func TestGetConsolidatedConfig(t *testing.T) {
 			},
 			// arg: "username=user",
 			config: Config{
-				URL:                   null.StringFrom(u.String()),
+				ServerURL:             null.StringFrom(u.String()),
 				InsecureSkipTLSVerify: null.BoolFrom(false),
 				Username:              null.NewString("u", true),
 				Password:              null.NewString("", false),
@@ -144,7 +144,7 @@ func TestGetConsolidatedConfig(t *testing.T) {
 			},
 			// arg: "password=arg",
 			config: Config{
-				URL:                   null.StringFrom("http://json:9090"),
+				ServerURL:             null.StringFrom("http://json:9090"),
 				InsecureSkipTLSVerify: null.BoolFrom(true),
 				Username:              null.StringFrom("env"),
 				Password:              null.StringFrom("env"),
@@ -181,16 +181,16 @@ func TestGetConsolidatedConfig(t *testing.T) {
 	}
 }
 
-func TestParseURL(t *testing.T) {
+func TestParseServerURL(t *testing.T) {
 	t.Parallel()
 
 	c, err := parseArg("url=http://prometheus.remote:3412/write")
 	assert.Nil(t, err)
-	assert.Equal(t, null.StringFrom("http://prometheus.remote:3412/write"), c.URL)
+	assert.Equal(t, null.StringFrom("http://prometheus.remote:3412/write"), c.ServerURL)
 
 	c, err = parseArg("url=http://prometheus.remote:3412/write,insecureSkipTLSVerify=false,pushInterval=2s")
 	assert.Nil(t, err)
-	assert.Equal(t, null.StringFrom("http://prometheus.remote:3412/write"), c.URL)
+	assert.Equal(t, null.StringFrom("http://prometheus.remote:3412/write"), c.ServerURL)
 	assert.Equal(t, null.BoolFrom(false), c.InsecureSkipTLSVerify)
 	assert.Equal(t, types.NullDurationFrom(time.Second*2), c.PushInterval)
 
@@ -199,7 +199,7 @@ func TestParseURL(t *testing.T) {
 	assert.Equal(t, map[string]string{"X-Header": "value"}, c.Headers)
 }
 
-func TestOptionURL(t *testing.T) {
+func TestOptionServerURL(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]struct {
@@ -213,7 +213,7 @@ func TestOptionURL(t *testing.T) {
 	}
 
 	expconfig := Config{
-		URL:                   null.StringFrom("http://prometheus:9090/api/v1/write"),
+		ServerURL:             null.StringFrom("http://prometheus:9090/api/v1/write"),
 		InsecureSkipTLSVerify: null.BoolFrom(true),
 		Username:              null.NewString("", false),
 		Password:              null.NewString("", false),
@@ -246,7 +246,7 @@ func TestOptionHeaders(t *testing.T) {
 	}
 
 	expconfig := Config{
-		URL:                   null.StringFrom("http://localhost:9090/api/v1/write"),
+		ServerURL:             null.StringFrom("http://localhost:9090/api/v1/write"),
 		InsecureSkipTLSVerify: null.BoolFrom(true),
 		PushInterval:          types.NullDurationFrom(5 * time.Second),
 		Headers: map[string]string{
@@ -280,7 +280,7 @@ func TestOptionInsecureSkipTLSVerify(t *testing.T) {
 	}
 
 	expconfig := Config{
-		URL:                   null.StringFrom(defaultURL),
+		ServerURL:             null.StringFrom(defaultServerURL),
 		InsecureSkipTLSVerify: null.BoolFrom(false),
 		PushInterval:          types.NullDurationFrom(defaultPushInterval),
 		Headers:               make(map[string]string),
@@ -311,7 +311,7 @@ func TestOptionBasicAuth(t *testing.T) {
 	}
 
 	expconfig := Config{
-		URL:                   null.StringFrom("http://localhost:9090/api/v1/write"),
+		ServerURL:             null.StringFrom("http://localhost:9090/api/v1/write"),
 		InsecureSkipTLSVerify: null.BoolFrom(true),
 		Username:              null.StringFrom("user1"),
 		Password:              null.StringFrom("pass1"),
@@ -345,7 +345,7 @@ func TestOptionTrendAsNativeHistogram(t *testing.T) {
 	}
 
 	expconfig := Config{
-		URL:                    null.StringFrom("http://localhost:9090/api/v1/write"),
+		ServerURL:              null.StringFrom("http://localhost:9090/api/v1/write"),
 		InsecureSkipTLSVerify:  null.BoolFrom(true),
 		Username:               null.NewString("", false),
 		Password:               null.NewString("", false),
@@ -380,7 +380,7 @@ func TestOptionPushInterval(t *testing.T) {
 	}
 
 	expconfig := Config{
-		URL:                   null.StringFrom("http://localhost:9090/api/v1/write"),
+		ServerURL:             null.StringFrom("http://localhost:9090/api/v1/write"),
 		InsecureSkipTLSVerify: null.BoolFrom(true),
 		Username:              null.NewString("", false),
 		Password:              null.NewString("", false),
@@ -415,7 +415,7 @@ func TestConfigTrendStats(t *testing.T) {
 	}
 
 	expconfig := Config{
-		URL:                   null.StringFrom("http://localhost:9090/api/v1/write"),
+		ServerURL:             null.StringFrom("http://localhost:9090/api/v1/write"),
 		InsecureSkipTLSVerify: null.BoolFrom(true),
 		PushInterval:          types.NullDurationFrom(5 * time.Second),
 		Headers:               make(map[string]string),

--- a/pkg/remotewrite/remotewrite.go
+++ b/pkg/remotewrite/remotewrite.go
@@ -52,7 +52,7 @@ func New(params output.Params) (*Output, error) {
 		return nil, err
 	}
 
-	wc, err := remote.NewWriteClient(config.URL.String, clientConfig)
+	wc, err := remote.NewWriteClient(config.ServerURL.String, clientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize the Prometheus remote write client: %w", err)
 	}
@@ -73,7 +73,7 @@ func New(params output.Params) (*Output, error) {
 }
 
 func (o *Output) Description() string {
-	return fmt.Sprintf("Prometheus remote write (%s)", o.config.URL.String)
+	return fmt.Sprintf("Prometheus remote write (%s)", o.config.ServerURL.String)
 }
 
 func (o *Output) Start() error {

--- a/pkg/remotewrite/remotewrite_test.go
+++ b/pkg/remotewrite/remotewrite_test.go
@@ -17,7 +17,7 @@ func TestOutputDescription(t *testing.T) {
 	t.Parallel()
 	o := Output{
 		config: Config{
-			URL: null.StringFrom("http://remote-url.fake"),
+			ServerURL: null.StringFrom("http://remote-url.fake"),
 		},
 	}
 	exp := "Prometheus remote write (http://remote-url.fake)"

--- a/register.go
+++ b/register.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	output.RegisterExtension("output-prometheus-remote", func(p output.Params) (output.Output, error) {
+	output.RegisterExtension("xk6-prometheus-rw", func(p output.Params) (output.Output, error) {
 		return remotewrite.New(p)
 	})
 }


### PR DESCRIPTION
It renames the registered name from `"output-prometheus-remote` to `xk6-prometheus-rw` and it makes the env vars consistent with the new name renaming the prefix to `K6_PROMETHEUS_RW_*`