### PR TITLE
Add k6's linting rules and address detected issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,85 @@
+# v1.47.2
+# Please don't remove the first line. It uses in CI to determine the golangci version
+run:
+  deadline: 5m
+
+issues:
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+
+  # We want to try and improve the comments in the k6 codebase, so individual
+  # non-golint items from the default exclusion list will gradually be addded
+  # to the exclude-rules below
+  exclude-use-default: false
+
+  exclude-rules:
+    # Exclude duplicate code and function length and complexity checking in test
+    # files (due to common repeats and long functions in test code)
+    - path: _(test|gen)\.go
+      linters:
+        - cyclop
+        - dupl
+        - gocognit
+        - funlen
+        - lll
+    - linters:
+        - paralleltest # false positive: https://github.com/kunwardeep/paralleltest/issues/8.
+      text: "does not use range value in test Run"
+
+linters-settings:
+  nolintlint:
+    # Disable to ensure that nolint directives don't have a leading space. Default is true.
+    allow-leading-space: false
+  exhaustive:
+    default-signifies-exhaustive: true
+  govet:
+    check-shadowing: true
+  cyclop:
+    max-complexity: 25
+  maligned:
+    suggest-new: true
+  dupl:
+    threshold: 150
+  goconst:
+    min-len: 10
+    min-occurrences: 4
+  funlen:
+    lines: 80
+    statements: 60
+
+linters:
+  enable-all: true
+  disable:
+    - nlreturn
+    - gci
+    - gochecknoinits
+    - godot
+    - godox
+    - gomodguard
+    - testpackage
+    - wsl
+    - gomnd
+    - goerr113 # most of the errors here are meant for humans
+    - goheader
+    - exhaustivestruct
+    - thelper
+    - gocyclo # replaced by cyclop since it also calculates the package complexity
+    - maligned # replaced by govet 'fieldalignment'
+    - interfacer # deprecated
+    - scopelint # deprecated, replaced by exportloopref
+    - wrapcheck # a little bit too much for k6, maybe after https://github.com/tomarrell/wrapcheck/issues/2 is fixed
+    - golint # this linter is deprecated
+    - varnamelen
+    - ireturn
+    - tagliatelle
+    - exhaustruct
+    - execinquery
+    - maintidx
+    - grouper
+    - decorder
+    - nonamedreturns
+    - nosnakecase
+    - containedctx
+  fast: false

--- a/pkg/remote/client_test.go
+++ b/pkg/remote/client_test.go
@@ -88,7 +88,7 @@ func TestClientStore(t *testing.T) {
 func TestClientStoreHTTPError(t *testing.T) {
 	t.Parallel()
 	h := func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "bad bad", http.StatusUnauthorized)
+		http.Error(w, "bad", http.StatusUnauthorized)
 	}
 	ts := httptest.NewServer(http.HandlerFunc(h))
 	defer ts.Close()
@@ -159,6 +159,7 @@ func TestClientStoreHeaders(t *testing.T) {
 }
 
 func TestNewWriteRequestBody(t *testing.T) {
+	t.Parallel()
 	ts := []*prompb.TimeSeries{
 		{
 			Labels:  []*prompb.Label{{Name: "label1", Value: "val1"}},

--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -21,8 +21,10 @@ const (
 	defaultMetricPrefix = "k6_"
 )
 
+//nolint:gochecknoglobals
 var defaultTrendStats = []string{"p(99)"}
 
+// Config contains the configuration for the Output.
 type Config struct {
 	// ServerURL contains the absolute ServerURL for the Write endpoint where to flush the time series.
 	ServerURL null.String `json:"url"`
@@ -81,7 +83,7 @@ func (conf Config) RemoteConfig() (*remote.HTTPConfig, error) {
 	}
 
 	hc.TLSConfig = &tls.Config{
-		InsecureSkipVerify: conf.InsecureSkipTLSVerify.Bool,
+		InsecureSkipVerify: conf.InsecureSkipTLSVerify.Bool, //nolint:gosec
 	}
 
 	if len(conf.Headers) > 0 {
@@ -94,43 +96,43 @@ func (conf Config) RemoteConfig() (*remote.HTTPConfig, error) {
 }
 
 // Apply merges applied Config into base.
-func (base Config) Apply(applied Config) Config {
+func (conf Config) Apply(applied Config) Config {
 	if applied.ServerURL.Valid {
-		base.ServerURL = applied.ServerURL
+		conf.ServerURL = applied.ServerURL
 	}
 
 	if applied.InsecureSkipTLSVerify.Valid {
-		base.InsecureSkipTLSVerify = applied.InsecureSkipTLSVerify
+		conf.InsecureSkipTLSVerify = applied.InsecureSkipTLSVerify
 	}
 
 	if applied.Username.Valid {
-		base.Username = applied.Username
+		conf.Username = applied.Username
 	}
 
 	if applied.Password.Valid {
-		base.Password = applied.Password
+		conf.Password = applied.Password
 	}
 
 	if applied.PushInterval.Valid {
-		base.PushInterval = applied.PushInterval
+		conf.PushInterval = applied.PushInterval
 	}
 
 	if applied.TrendAsNativeHistogram.Valid {
-		base.TrendAsNativeHistogram = applied.TrendAsNativeHistogram
+		conf.TrendAsNativeHistogram = applied.TrendAsNativeHistogram
 	}
 
 	if len(applied.Headers) > 0 {
 		for k, v := range applied.Headers {
-			base.Headers[k] = v
+			conf.Headers[k] = v
 		}
 	}
 
 	if len(applied.TrendStats) > 0 {
-		base.TrendStats = make([]string, len(applied.TrendStats))
-		copy(base.TrendStats, applied.TrendStats)
+		conf.TrendStats = make([]string, len(applied.TrendStats))
+		copy(conf.TrendStats, applied.TrendStats)
 	}
 
-	return base
+	return conf
 }
 
 // GetConsolidatedConfig combines the options' values from the different sources
@@ -156,6 +158,7 @@ func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, u
 
 	// TODO: define a way for defining Output's options
 	// then support them.
+	//nolint:gocritic
 	//
 	//if url != "" {
 	//urlConf, err := parseArg(url)
@@ -173,11 +176,12 @@ func parseEnvs(env map[string]string) (Config, error) {
 
 	getEnvBool := func(env map[string]string, name string) (null.Bool, error) {
 		if v, vDefined := env[name]; vDefined {
-			if b, err := strconv.ParseBool(v); err != nil {
+			b, err := strconv.ParseBool(v)
+			if err != nil {
 				return null.NewBool(false, false), err
-			} else {
-				return null.BoolFrom(b), nil
 			}
+
+			return null.BoolFrom(b), nil
 		}
 		return null.NewBool(false, false), nil
 	}
@@ -205,10 +209,8 @@ func parseEnvs(env map[string]string) (Config, error) {
 
 	if b, err := getEnvBool(env, "K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY"); err != nil {
 		return c, err
-	} else {
-		if b.Valid {
-			c.InsecureSkipTLSVerify = b
-		}
+	} else if b.Valid {
+		c.InsecureSkipTLSVerify = b
 	}
 
 	if user, userDefined := env["K6_PROMETHEUS_RW_USERNAME"]; userDefined {
@@ -229,10 +231,8 @@ func parseEnvs(env map[string]string) (Config, error) {
 
 	if b, err := getEnvBool(env, "K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM"); err != nil {
 		return c, err
-	} else {
-		if b.Valid {
-			c.TrendAsNativeHistogram = b
-		}
+	} else if b.Valid {
+		c.TrendAsNativeHistogram = b
 	}
 
 	if trendStats, trendStatsDefined := env["K6_PROMETHEUS_RW_TREND_STATS"]; trendStatsDefined {
@@ -284,6 +284,7 @@ func parseArg(text string) (Config, error) {
 		// strvals doesn't support the same format used by --summary-trend-stats
 		// using the comma as the separator, because it is already used for
 		// dividing the keys.
+		//nolint:gocritic
 		//
 		//if v, ok := params["trendStats"].(string); ok && len(v) > 0 {
 		//c.TrendStats = strings.Split(v, ",")

--- a/pkg/remotewrite/config_test.go
+++ b/pkg/remotewrite/config_test.go
@@ -49,6 +49,7 @@ func TestConfigApply(t *testing.T) {
 }
 
 func TestConfigRemoteConfig(t *testing.T) {
+	t.Parallel()
 	u, err := url.Parse("https://prometheus.ie/remote")
 	require.NoError(t, err)
 
@@ -67,7 +68,7 @@ func TestConfigRemoteConfig(t *testing.T) {
 	exprcc := &remote.HTTPConfig{
 		Timeout: 5 * time.Second,
 		TLSConfig: &tls.Config{
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: true, //nolint:gosec
 		},
 		BasicAuth: &remote.BasicAuth{
 			Username: "myuser",
@@ -161,6 +162,7 @@ func TestGetConsolidatedConfig(t *testing.T) {
 			env:       map[string]string{"K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY": "d"},
 			errString: "parse environment variables options failed",
 		},
+		//nolint:gocritic
 		//"InvalidArg": {
 		//arg:       "insecureSkipTLSVerify=wrongtime",
 		//errString: "parse argument string options failed",
@@ -170,6 +172,7 @@ func TestGetConsolidatedConfig(t *testing.T) {
 	for name, testCase := range testCases {
 		testCase := testCase
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			c, err := GetConsolidatedConfig(testCase.jsonRaw, testCase.env, testCase.arg)
 			if len(testCase.errString) > 0 {
 				require.NotNil(t, err)
@@ -209,6 +212,7 @@ func TestOptionServerURL(t *testing.T) {
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"url":"http://prometheus:9090/api/v1/write"}`)},
 		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_SERVER_URL": "http://prometheus:9090/api/v1/write"}},
+		//nolint:gocritic
 		//"Arg":  {arg: "url=http://prometheus:9090/api/v1/write"},
 	}
 
@@ -224,6 +228,7 @@ func TestOptionServerURL(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			c, err := GetConsolidatedConfig(
 				tc.jsonRaw, tc.env, tc.arg)
 			require.NoError(t, err)
@@ -242,6 +247,7 @@ func TestOptionHeaders(t *testing.T) {
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"headers":{"X-MY-HEADER1":"hval1","X-MY-HEADER2":"hval2"}}`)},
 		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_HEADERS_X-MY-HEADER1": "hval1", "K6_PROMETHEUS_RW_HEADERS_X-MY-HEADER2": "hval2"}},
+		//nolint:gocritic
 		//"Arg":  {arg: "headers.X-MY-HEADER1=hval1,headers.X-MY-HEADER2=hval2"},
 	}
 
@@ -258,6 +264,7 @@ func TestOptionHeaders(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			c, err := GetConsolidatedConfig(
 				tc.jsonRaw, tc.env, tc.arg)
 			require.NoError(t, err)
@@ -276,6 +283,7 @@ func TestOptionInsecureSkipTLSVerify(t *testing.T) {
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"insecureSkipTLSVerify":false}`)},
 		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY": "false"}},
+		//nolint:gocritic
 		//"Arg":  {arg: "insecureSkipTLSVerify=false"},
 	}
 
@@ -289,6 +297,7 @@ func TestOptionInsecureSkipTLSVerify(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			c, err := GetConsolidatedConfig(
 				tc.jsonRaw, tc.env, tc.arg)
 			require.NoError(t, err)
@@ -307,6 +316,7 @@ func TestOptionBasicAuth(t *testing.T) {
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"username":"user1","password":"pass1"}`)},
 		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_USERNAME": "user1", "K6_PROMETHEUS_RW_PASSWORD": "pass1"}},
+		//nolint:gocritic
 		//"Arg":  {arg: "username=user1,password=pass1"},
 	}
 
@@ -323,6 +333,7 @@ func TestOptionBasicAuth(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			c, err := GetConsolidatedConfig(
 				tc.jsonRaw, tc.env, tc.arg)
 			require.NoError(t, err)
@@ -341,6 +352,7 @@ func TestOptionTrendAsNativeHistogram(t *testing.T) {
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"trendAsNativeHistogram":true}`)},
 		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM": "true"}},
+		//nolint:gocritic
 		//"Arg":  {arg: "trendAsNativeHistogram=true"},
 	}
 
@@ -358,6 +370,7 @@ func TestOptionTrendAsNativeHistogram(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			c, err := GetConsolidatedConfig(
 				tc.jsonRaw, tc.env, tc.arg)
 			require.NoError(t, err)
@@ -376,6 +389,7 @@ func TestOptionPushInterval(t *testing.T) {
 	}{
 		"JSON": {jsonRaw: json.RawMessage(`{"pushInterval":"1m2s"}`)},
 		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_PUSH_INTERVAL": "1m2s"}},
+		//nolint:gocritic
 		//"Arg":  {arg: "pushInterval=1m2s"},
 	}
 
@@ -392,6 +406,7 @@ func TestOptionPushInterval(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			c, err := GetConsolidatedConfig(
 				tc.jsonRaw, tc.env, tc.arg)
 			require.NoError(t, err)
@@ -411,6 +426,7 @@ func TestConfigTrendStats(t *testing.T) {
 		"JSON": {jsonRaw: json.RawMessage(`{"trendStats":["max","p(95)"]}`)},
 		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_TREND_STATS": "max,p(95)"}},
 		// TODO: support arg, check the comment in the code
+		//nolint:gocritic
 		//"Arg":  {arg: "trendStats=max,p(95)"},
 	}
 
@@ -425,6 +441,7 @@ func TestConfigTrendStats(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			c, err := GetConsolidatedConfig(
 				tc.jsonRaw, tc.env, tc.arg)
 			require.NoError(t, err)

--- a/pkg/remotewrite/prometheus_test.go
+++ b/pkg/remotewrite/prometheus_test.go
@@ -37,7 +37,7 @@ func TestMapSeries(t *testing.T) {
 }
 
 // buildTimeSeries creates a TimSeries with the given name, value and timestamp
-func buildTimeSeries(name string, value float64, timestamp time.Time) *prompb.TimeSeries {
+func buildTimeSeries(name string, value float64, timestamp time.Time) *prompb.TimeSeries { //nolint:unparam
 	return &prompb.TimeSeries{
 		Labels: []*prompb.Label{
 			{

--- a/pkg/remotewrite/remotewrite_test.go
+++ b/pkg/remotewrite/remotewrite_test.go
@@ -109,6 +109,7 @@ func TestOutputConvertToPbSeries(t *testing.T) {
 	assert.Equal(t, exp, pbseries)
 }
 
+//nolint:paralleltest,tparallel
 func TestOutputConvertToPbSeries_WithPreviousState(t *testing.T) {
 	t.Parallel()
 
@@ -164,6 +165,7 @@ func TestOutputConvertToPbSeries_WithPreviousState(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			pbseries := o.convertToPbSeries([]metrics.SampleContainer{
 				metrics.Sample{
@@ -177,7 +179,7 @@ func TestOutputConvertToPbSeries_WithPreviousState(t *testing.T) {
 			})
 			require.Len(t, o.tsdb, 1)
 			require.Equal(t, tc.expSeries, len(pbseries))
-			assert.Equal(t, tc.expCount, swm.Measure.(*metrics.CounterSink).Value)
+			assert.Equal(t, tc.expCount, swm.Measure.(*metrics.CounterSink).Value) //nolint:forcetypeassert
 			assert.Equal(t, tc.expLatest, swm.Latest)
 		})
 	}

--- a/pkg/remotewrite/trend.go
+++ b/pkg/remotewrite/trend.go
@@ -11,6 +11,7 @@ import (
 	"go.k6.io/k6/metrics"
 )
 
+// TrendStatsResolver is a map of trend stats name and their relative resolver function
 type TrendStatsResolver map[string]func(*metrics.TrendSink) float64
 
 type extendedTrendSink struct {

--- a/pkg/remotewrite/trend_test.go
+++ b/pkg/remotewrite/trend_test.go
@@ -169,7 +169,7 @@ func BenchmarkK6TrendSinkAdd(b *testing.B) {
 		TimeSeries: metrics.TimeSeries{
 			Metric: m,
 		},
-		Value: rand.Float64(),
+		Value: rand.Float64(), //nolint:gosec
 		Time:  time.Now(),
 	}
 	b.ResetTimer()
@@ -229,7 +229,7 @@ func BenchmarkHistogramSinkAdd(b *testing.B) {
 		TimeSeries: metrics.TimeSeries{
 			Metric: m,
 		},
-		Value: rand.Float64(),
+		Value: rand.Float64(), //nolint:gosec
 		Time:  time.Now(),
 	}
 	b.ResetTimer()

--- a/register.go
+++ b/register.go
@@ -1,3 +1,4 @@
+// Package remotewrite registers the xk6-output-prometheus-remote extension
 package remotewrite
 
 import (


### PR DESCRIPTION
Here's a PR adding the k6 golangci-lint configuration to the repo and addressing the issues outlined by it. Note that in a bunch of places, I simply locally deactivated the lining rule as I was not 100% certain if things such as type casts being unchecked were intentional or not.

Let me know what you think, and if you spot things that could/should be done differently 🙇🏻 