### PR TITLE
Stale marker accuracy

### DIFF
--- a/pkg/remote/client_test.go
+++ b/pkg/remote/client_test.go
@@ -10,8 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/snappy"
 	"github.com/grafana/xk6-output-prometheus-remote/pkg/stale"
+
+	"github.com/golang/snappy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	prompb "go.buf.build/grpc/go/prometheus/prometheus"

--- a/pkg/stale/stale.go
+++ b/pkg/stale/stale.go
@@ -16,5 +16,9 @@ import "math"
 // The value is the same used by the Prometheus package.
 // https://pkg.go.dev/github.com/prometheus/prometheus/pkg/value#pkg-constants
 //
+// It isn't imported directly to avoid the direct dependency
+// from the big Prometheus project that would bring more
+// dependencies.
+//
 //nolint:gochecknoglobals
 var Marker = math.Float64frombits(0x7ff0000000000002)


### PR DESCRIPTION
~~It introduces a new option `K6_PROMETHEUS_RW_STALE_MARKERS=<bool>` for enabling the Staleness marking process at the end of the test. It also disables the option by default.~~ Moved to https://github.com/grafana/xk6-output-prometheus-remote/pull/86

It adjusts the stale marker accuracy by adding slight padding.