### PR TITLE
Stale marker option

### DIFF
--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -53,6 +53,8 @@ type Config struct {
 	//
 	// TODO: should we support K6_SUMMARY_TREND_STATS?
 	TrendStats []string `json:"trendStats"`
+
+	StaleMarkers null.Bool `json:"staleMarkers"`
 }
 
 // NewConfig creates an Output's configuration.
@@ -65,6 +67,7 @@ func NewConfig() Config {
 		PushInterval:          types.NullDurationFrom(defaultPushInterval),
 		Headers:               make(map[string]string),
 		TrendStats:            defaultTrendStats,
+		StaleMarkers:          null.BoolFrom(false),
 	}
 }
 
@@ -119,6 +122,10 @@ func (conf Config) Apply(applied Config) Config {
 
 	if applied.TrendAsNativeHistogram.Valid {
 		conf.TrendAsNativeHistogram = applied.TrendAsNativeHistogram
+	}
+
+	if applied.StaleMarkers.Valid {
+		conf.StaleMarkers = applied.StaleMarkers
 	}
 
 	if len(applied.Headers) > 0 {
@@ -233,6 +240,12 @@ func parseEnvs(env map[string]string) (Config, error) {
 		return c, err
 	} else if b.Valid {
 		c.TrendAsNativeHistogram = b
+	}
+
+	if b, err := getEnvBool(env, "K6_PROMETHEUS_RW_STALE_MARKERS"); err != nil {
+		return c, err
+	} else if b.Valid {
+		c.StaleMarkers = b
 	}
 
 	if trendStats, trendStatsDefined := env["K6_PROMETHEUS_RW_TREND_STATS"]; trendStatsDefined {

--- a/pkg/remotewrite/config_test.go
+++ b/pkg/remotewrite/config_test.go
@@ -28,7 +28,8 @@ func TestConfigApply(t *testing.T) {
 		Headers: map[string]string{
 			"X-Header": "value",
 		},
-		TrendStats: []string{"p(99)"},
+		TrendStats:   []string{"p(99)"},
+		StaleMarkers: null.BoolFrom(true),
 	}
 
 	// Defaults should be overwritten by valid values
@@ -106,6 +107,7 @@ func TestGetConsolidatedConfig(t *testing.T) {
 				PushInterval:          types.NullDurationFrom(5 * time.Second),
 				Headers:               make(map[string]string),
 				TrendStats:            []string{"p(99)"},
+				StaleMarkers:          null.BoolFrom(false),
 			},
 		},
 		"JSONSuccess": {
@@ -118,6 +120,7 @@ func TestGetConsolidatedConfig(t *testing.T) {
 				PushInterval:          types.NullDurationFrom(defaultPushInterval),
 				Headers:               make(map[string]string),
 				TrendStats:            []string{"p(99)"},
+				StaleMarkers:          null.BoolFrom(false),
 			},
 		},
 		"MixedSuccess": {
@@ -135,6 +138,7 @@ func TestGetConsolidatedConfig(t *testing.T) {
 				PushInterval:          types.NullDurationFrom(defaultPushInterval),
 				Headers:               make(map[string]string),
 				TrendStats:            []string{"p(99)"},
+				StaleMarkers:          null.BoolFrom(false),
 			},
 		},
 		"OrderOfPrecedence": {
@@ -152,6 +156,7 @@ func TestGetConsolidatedConfig(t *testing.T) {
 				PushInterval:          types.NullDurationFrom(defaultPushInterval),
 				Headers:               make(map[string]string),
 				TrendStats:            []string{"p(99)"},
+				StaleMarkers:          null.BoolFrom(false),
 			},
 		},
 		"InvalidJSON": {
@@ -224,6 +229,7 @@ func TestOptionServerURL(t *testing.T) {
 		PushInterval:          types.NullDurationFrom(5 * time.Second),
 		Headers:               make(map[string]string),
 		TrendStats:            []string{"p(99)"},
+		StaleMarkers:          null.BoolFrom(false),
 	}
 	for name, tc := range cases {
 		tc := tc
@@ -259,7 +265,8 @@ func TestOptionHeaders(t *testing.T) {
 			"X-MY-HEADER1": "hval1",
 			"X-MY-HEADER2": "hval2",
 		},
-		TrendStats: []string{"p(99)"},
+		TrendStats:   []string{"p(99)"},
+		StaleMarkers: null.BoolFrom(false),
 	}
 	for name, tc := range cases {
 		tc := tc
@@ -293,6 +300,7 @@ func TestOptionInsecureSkipTLSVerify(t *testing.T) {
 		PushInterval:          types.NullDurationFrom(defaultPushInterval),
 		Headers:               make(map[string]string),
 		TrendStats:            []string{"p(99)"},
+		StaleMarkers:          null.BoolFrom(false),
 	}
 	for name, tc := range cases {
 		tc := tc
@@ -328,6 +336,7 @@ func TestOptionBasicAuth(t *testing.T) {
 		PushInterval:          types.NullDurationFrom(5 * time.Second),
 		Headers:               make(map[string]string),
 		TrendStats:            []string{"p(99)"},
+		StaleMarkers:          null.BoolFrom(false),
 	}
 
 	for name, tc := range cases {
@@ -365,6 +374,7 @@ func TestOptionTrendAsNativeHistogram(t *testing.T) {
 		Headers:                make(map[string]string),
 		TrendAsNativeHistogram: null.BoolFrom(true),
 		TrendStats:             []string{"p(99)"},
+		StaleMarkers:           null.BoolFrom(false),
 	}
 
 	for name, tc := range cases {
@@ -401,6 +411,7 @@ func TestOptionPushInterval(t *testing.T) {
 		PushInterval:          types.NullDurationFrom((1 * time.Minute) + (2 * time.Second)),
 		Headers:               make(map[string]string),
 		TrendStats:            []string{"p(99)"},
+		StaleMarkers:          null.BoolFrom(false),
 	}
 
 	for name, tc := range cases {
@@ -436,6 +447,40 @@ func TestConfigTrendStats(t *testing.T) {
 		PushInterval:          types.NullDurationFrom(5 * time.Second),
 		Headers:               make(map[string]string),
 		TrendStats:            []string{"max", "p(95)"},
+		StaleMarkers:          null.BoolFrom(false),
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			c, err := GetConsolidatedConfig(
+				tc.jsonRaw, tc.env, tc.arg)
+			require.NoError(t, err)
+			assert.Equal(t, expconfig, c)
+		})
+	}
+}
+
+func TestOptionStaleMarker(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		arg     string
+		env     map[string]string
+		jsonRaw json.RawMessage
+	}{
+		"JSON": {jsonRaw: json.RawMessage(`{"staleMarkers":true}`)},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_STALE_MARKERS": "true"}},
+	}
+
+	expconfig := Config{
+		ServerURL:             null.StringFrom("http://localhost:9090/api/v1/write"),
+		InsecureSkipTLSVerify: null.BoolFrom(true),
+		PushInterval:          types.NullDurationFrom(5 * time.Second),
+		Headers:               make(map[string]string),
+		TrendStats:            []string{"p(99)"},
+		StaleMarkers:          null.BoolFrom(true),
 	}
 
 	for name, tc := range cases {

--- a/pkg/remotewrite/remotewrite_test.go
+++ b/pkg/remotewrite/remotewrite_test.go
@@ -2,13 +2,17 @@ package remotewrite
 
 import (
 	"fmt"
+	"io"
 	"math"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	prompb "go.buf.build/grpc/go/prometheus/prometheus"
+	"go.k6.io/k6/lib/testutils"
+	"go.k6.io/k6/lib/types"
 	"go.k6.io/k6/metrics"
 	"gopkg.in/guregu/null.v3"
 )
@@ -339,5 +343,54 @@ func TestOutputStaleMarkers(t *testing.T) {
 		assert.Equal(t, expName, markers[i].Labels[0].Value)
 		assert.Equal(t, now.UnixMilli(), markers[i].Samples[0].Timestamp)
 		assert.True(t, math.IsNaN(markers[i].Samples[0].Value), "it isn't a StaleNaN value")
+	}
+}
+
+func TestOutputStopWithStaleMarkers(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []bool{true, false} {
+		logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.DebugLevel}}
+		logger := logrus.New()
+		logger.SetLevel(logrus.DebugLevel)
+		logger.AddHook(logHook)
+		logger.SetOutput(io.Discard)
+
+		o := Output{
+			logger: logger,
+			config: Config{
+				// setting a large interval so it does not trigger
+				PushInterval: types.NullDurationFrom(1 * time.Hour),
+				StaleMarkers: null.BoolFrom(tc),
+			},
+		}
+
+		err := o.Start()
+		require.NoError(t, err)
+		err = o.Stop()
+		require.NoError(t, err)
+
+		// TODO: it isn't optimal to maintain
+		// if a new logline is added in Start or flushMetrics
+		// then this test will break
+		// A mock of the client and check if Store is invoked
+		// should be a more stable method.
+		entries := logHook.Drain()
+		require.NotEmpty(t, entries)
+
+		messages := func() []string {
+			s := make([]string, 0, len(entries))
+			for _, e := range entries {
+				s = append(s, e.Message)
+			}
+			return s
+		}()
+
+		msg := "No time series to mark as stale"
+		assertfn := assert.Contains
+		if !tc {
+			assertfn = assert.NotContains
+		}
+		assertfn(t, messages, msg)
 	}
 }

--- a/pkg/stale/stale.go
+++ b/pkg/stale/stale.go
@@ -1,0 +1,20 @@
+// Package stale handles the staleness process.
+//
+// TODO: migrate here more logic dedicated to this topic
+// from the remote write package.
+package stale
+
+import "math"
+
+// Marker is the Prometheus Remote Write special value for marking
+// a time series as stale.
+//
+// Check https://www.robustperception.io/staleness-and-promql and
+// https://prometheus.io/docs/prometheus/latest/querying/basics/#staleness
+// for details about the Prometheus staleness markers.
+//
+// The value is the same used by the Prometheus package.
+// https://pkg.go.dev/github.com/prometheus/prometheus/pkg/value#pkg-constants
+//
+//nolint:gochecknoglobals
+var Marker = math.Float64frombits(0x7ff0000000000002)


### PR DESCRIPTION
It introduces a new option `K6_PROMETHEUS_RW_STALE_MARKERS=<bool>` for enabling the Staleness marking process at the end of the test. It also disables the option by default.
