### PR TITLE
adding client certificate and key

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,11 @@ Clone the repo to get started and follow these steps:
 3. Visit http://localhost:3000/ to view results in Grafana.
 
 ## Dashboards
-
-The docker-compose setup comes with two pre-built dashboards. One for listing the discrete test runs as a list, and the other for visualizing the results of a specific test run.
-
-### Test list dashboard
-
-![Prometheus dashboard of k6 test runs](./images/prometheus-dashboard-k6-test-runs.png)
+The docker-compose setup comes with two pre-built Grafana dashboards. One for listing the discrete test runs as a list, and the other for visualizing the results of a specific test run.
 
 ### Test result dashboard
-
 ![Prometheus dashboard of k6 test result](./images/prometheus-dashboard-k6-test-result.png)
+
+### Test list dashboard
+![Prometheus dashboard of k6 test runs](./images/prometheus-dashboard-k6-test-runs.png)
+

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ K6_PROMETHEUS_RW_PASSWORD=bar \
 ./k6 run -o xk6-prometheus-rw script.js 
 ```
 
+or with client certificate:
+```
+K6_PROMETHEUS_RW_SERVER_URL=https://localhost:9090/api/v1/write \
+K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY=false \
+K6_PROMETHEUS_RW_CLIENT_CERTIFICATE=client.crt \
+K6_PROMETHEUS_RW_CLIENT_CERTIFICATE_KEY=client.key \
+./k6 run -o xk6-prometheus-rw script.js
+```
+
 ### Metric types conversions
 
 All the k6 metric types are converted into an equivalent Prometheus' type:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ xk6 build --with github.com/grafana/xk6-output-prometheus-remote@latest
 
 Then run new k6 binary with:
 ```
-K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write ./k6 run script.js -o output-prometheus-remote
+K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write ./k6 run -o xk6-prometheus-rw script.js 
 ```
 
 Add TLS and HTTP basic authentication:
@@ -29,7 +29,7 @@ K6_PROMETHEUS_RW_SERVER_URL=https://localhost:9090/api/v1/write \
 K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY=false \
 K6_PROMETHEUS_RW_USERNAME=foo \
 K6_PROMETHEUS_RW_PASSWORD=bar \
-./k6 run script.js -o output-prometheus-remote
+./k6 run -o xk6-prometheus-rw script.js 
 ```
 
 ### Metric types conversions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     environment:
       - K6_PROMETHEUS_RW_SERVER_URL=http://prometheus:9090/api/v1/write
       - K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=true
-      - K6_OUT=output-prometheus-remote
+      - K6_OUT=xk6-prometheus-rw
     depends_on:
       - prometheus
     volumes:

--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -79,7 +79,6 @@ func (conf Config) RemoteConfig() (*remote.HTTPConfig, error) {
 	hc := remote.HTTPConfig{
 		Timeout: defaultTimeout,
 	}
-	clientCertificate := true
 
 	// if at least valid user was configured, use basic auth
 	if conf.Username.Valid {
@@ -93,8 +92,8 @@ func (conf Config) RemoteConfig() (*remote.HTTPConfig, error) {
 		InsecureSkipVerify: conf.InsecureSkipTLSVerify.Bool,
 	}
 
-	if clientCertificate {
-		cert, _ := tls.LoadX509KeyPair("client.crt", "client.key")
+	if conf.ClientCertificate.Valid && conf.ClientCertificateKey.Valid {
+		cert, _ := tls.LoadX509KeyPair(conf.ClientCertificate.String, conf.ClientCertificateKey.String)
 		hc.TLSConfig.Certificates = []tls.Certificate{cert}
 	}
 

--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -25,32 +25,32 @@ var defaultTrendStats = []string{"p(99)"}
 
 type Config struct {
 	// ServerURL contains the absolute ServerURL for the Write endpoint where to flush the time series.
-	ServerURL null.String `json:"url" envconfig:"K6_PROMETHEUS_RW_SERVER_URL"`
+	ServerURL null.String `json:"url"`
 
 	// Headers contains additional headers that should be included in the HTTP requests.
-	Headers map[string]string `json:"headers" envconfig:"K6_PROMETHEUS_RW_HEADERS"`
+	Headers map[string]string `json:"headers"`
 
 	// InsecureSkipTLSVerify skips TLS client side checks.
-	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify" envconfig:"K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY"`
+	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify"`
 
 	// Username is the User for Basic Auth.
-	Username null.String `json:"username" envconfig:"K6_PROMETHEUS_RW_USERNAME"`
+	Username null.String `json:"username"`
 
 	// Password is the Password for the Basic Auth.
-	Password null.String `json:"password" envconfig:"K6_PROMETHEUS_RW_PASSWORD"`
+	Password null.String `json:"password"`
 
 	// PushInterval defines the time between flushes. The Output will wait the set time
 	// before push a new set of time series to the endpoint.
-	PushInterval types.NullDuration `json:"pushInterval" envconfig:"K6_PROMETHEUS_RW_PUSH_INTERVAL"`
+	PushInterval types.NullDuration `json:"pushInterval"`
 
 	// TrendAsNativeHistogram defines if the mapping for metrics defined as Trend type
 	// should map to a Prometheus' Native Histogram.
-	TrendAsNativeHistogram null.Bool `json:"trendAsNativeHistogram" envconfig:"K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM"`
+	TrendAsNativeHistogram null.Bool `json:"trendAsNativeHistogram"`
 
 	// TrendStats defines the stats to flush for Trend metrics.
 	//
 	// TODO: should we support K6_SUMMARY_TREND_STATS?
-	TrendStats []string `json:"trendStats" envconfig:"K6_PROMETHEUS_RW_TREND_STATS"`
+	TrendStats []string `json:"trendStats"`
 }
 
 // NewConfig creates an Output's configuration.
@@ -193,7 +193,6 @@ func parseEnvs(env map[string]string) (Config, error) {
 		return result
 	}
 
-	// envconfig is not processing some undefined vars (at least duration) so apply them manually
 	if pushInterval, pushIntervalDefined := env["K6_PROMETHEUS_RW_PUSH_INTERVAL"]; pushIntervalDefined {
 		if err := c.PushInterval.UnmarshalText([]byte(pushInterval)); err != nil {
 			return c, err

--- a/pkg/remotewrite/config_test.go
+++ b/pkg/remotewrite/config_test.go
@@ -366,6 +366,40 @@ func TestOptionTrendAsNativeHistogram(t *testing.T) {
 	}
 }
 
+func TestOptionClientCertificate(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		arg     string
+		env     map[string]string
+		jsonRaw json.RawMessage
+	}{
+		"JSON": {jsonRaw: json.RawMessage(`{"clientCertificate":"client.crt","clientCertificateKey":"client.key"}`)},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_CLIENT_CERTIFICATE": "client.crt", "K6_PROMETHEUS_RW_CLIENT_CERTIFICATE_KEY": "client.key"}},
+		//"Arg":  {arg: "username=user1,password=pass1"},
+	}
+
+	expconfig := Config{
+		ServerURL:             null.StringFrom("http://localhost:9090/api/v1/write"),
+		InsecureSkipTLSVerify: null.BoolFrom(true),
+		PushInterval:          types.NullDurationFrom(5 * time.Second),
+		Headers:               make(map[string]string),
+		TrendStats:            []string{"p(99)"},
+		ClientCertificate:     null.StringFrom("client.crt"),
+		ClientCertificateKey:  null.StringFrom("client.key"),
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			c, err := GetConsolidatedConfig(
+				tc.jsonRaw, tc.env, tc.arg)
+			require.NoError(t, err)
+			assert.Equal(t, expconfig, c)
+		})
+	}
+}
+
 func TestOptionPushInterval(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
hey there,

for our case we needed to add a client certificate and key to the configuration - I'd like to upstream my changes.

I hope this passes your standards - I've modified existing unit tests for configuration (I didn't do a full integration test with certificates because that would make the testing setup a lot more complex)
