### PR TITLE
Discard tags with empty fields

### DIFF
--- a/pkg/remotewrite/prometheus.go
+++ b/pkg/remotewrite/prometheus.go
@@ -21,8 +21,11 @@ func MapTagSet(t *metrics.TagSet) []*prompb.Label {
 	labels := make([]*prompb.Label, 0, n.Len())
 	for !n.IsRoot() {
 		prev, key, value := n.Data()
-		labels = append(labels, &prompb.Label{Name: key, Value: value})
 		n = prev
+		if key == "" || value == "" {
+			continue
+		}
+		labels = append(labels, &prompb.Label{Name: key, Value: value})
 	}
 	return labels
 }

--- a/pkg/remotewrite/prometheus_test.go
+++ b/pkg/remotewrite/prometheus_test.go
@@ -17,12 +17,19 @@ func TestMapSeries(t *testing.T) {
 	t.Parallel()
 
 	r := metrics.NewRegistry()
+	tags := r.RootTagSet().
+		With("tagk1", "tagv1").With("b1", "v1").
+		// labels with empty key or value are not allowed
+		// so they will be not added as labels
+		With("tagEmptyValue", "").
+		With("", "tagEmptyKey")
+
 	series := metrics.TimeSeries{
 		Metric: &metrics.Metric{
 			Name: "test",
 			Type: metrics.Counter,
 		},
-		Tags: r.RootTagSet().With("tagk1", "tagv1").With("b1", "v1"),
+		Tags: tags,
 	}
 
 	lbls := MapSeries(series, "")


### PR DESCRIPTION
Labels with empty key or value are not allowed by the remote write spec, so if any seen tag contains them then they are not mapped to the related label.

Prometheus server automatically discards them but other remote write implementations return a validation error. (e.g. Thanos).

Credits to @afajl that reports the issue.