### PR TITLE
Updated run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ xk6 build --with github.com/grafana/xk6-output-prometheus-remote@latest
 
 Then run new k6 binary with the following command for using the default configuration (e.g. remote write server url set to `http://localhost:9090/api/v1/write`):
 ```
-./k6 run -o xk6-prometheus-rw script.js 
+./k6 run -o experimental-prometheus-rw script.js 
 ```
 
 Check [the documentation](https://k6.io/docs/results-output/real-time/prometheus-remote-write) for advanced configurations, Docker Compose ready to use example or for using the builtin experimental output.


### PR DESCRIPTION
Using updated run command for prometheus remote write which support k0.45 using below command
`./k6 run -o experimental-prometheus-rw test.js`