### PR TITLE
Fix arm build

### DIFF
--- a/pkg/remote/client.go
+++ b/pkg/remote/client.go
@@ -117,7 +117,7 @@ func newWriteRequestBody(series []*prompb.TimeSeries) ([]byte, error) {
 	}
 	if snappy.MaxEncodedLen(len(b)) < 0 {
 		return nil, fmt.Errorf("the protobuf message is too large to be handled by Snappy encoder; "+
-			"size: %d, limit: %d", len(b), 0xffffffff)
+			"size: %d, limit: %d", len(b), uint(0xffffffff))
 	}
 	return snappy.Encode(nil, b), nil
 }


### PR DESCRIPTION
When trying to build for ARM (linux/arm), you get:

```
pkg/remote/client.go:120:35: cannot use 0xffffffff (untyped int constant 4294967295) as int value in argument to fmt.Errorf (overflows)
```

Pass the constant as unsigned integer.