### PR TITLE
Use issue auto-assigner

### DIFF
--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -1,0 +1,11 @@
+name: "Auto assign maintainer to issue"
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  assign-maintainer:
+    uses: grafana/k6/.github/workflows/issue-auto-assign.yml@master


### PR DESCRIPTION
## What?

Re-use autoassigner workflow from the k6.

## Why?

It helps with issue discovery.