### PR TITLE
Dashboards: fix `HTTP request failures` counter

### DIFF
--- a/grafana/dashboards/k6-prometheus-native-histogram.json
+++ b/grafana/dashboards/k6-prometheus-native-histogram.json
@@ -411,7 +411,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(k6_http_reqs_total{testid=~\"$testid\", expected_response=\"true\"})",
+          "expr": "sum(k6_http_reqs_total{testid=~\"$testid\", expected_response=\"false\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,

--- a/grafana/dashboards/k6-prometheus.json
+++ b/grafana/dashboards/k6-prometheus.json
@@ -411,7 +411,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(k6_http_reqs_total{testid=~\"$testid\", expected_response=\"true\"})",
+          "expr": "sum(k6_http_reqs_total{testid=~\"$testid\", expected_response=\"false\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,


### PR DESCRIPTION
Fixes the `HTTP requests failures` panel (#152)

The public dashboards have also been updated:
- https://grafana.com/grafana/dashboards/19665-k6-prometheus/
- https://grafana.com/grafana/dashboards/18030-k6-prometheus-native-histograms/