### PR TITLE
Fix the Bearer token parsing

### DIFF
--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -145,6 +145,10 @@ func (conf Config) Apply(applied Config) Config {
 		conf.Password = applied.Password
 	}
 
+	if applied.BearerToken.Valid {
+		conf.BearerToken = applied.BearerToken
+	}
+
 	if applied.PushInterval.Valid {
 		conf.PushInterval = applied.PushInterval
 	}
@@ -274,6 +278,10 @@ func parseEnvs(env map[string]string) (Config, error) {
 
 	if clientCertificateKey, certDefined := env["K6_PROMETHEUS_RW_CLIENT_CERTIFICATE_KEY"]; certDefined {
 		c.ClientCertificateKey = null.StringFrom(clientCertificateKey)
+	}
+
+	if token, tokenDefined := env["K6_PROMETHEUS_RW_BEARER_TOKEN"]; tokenDefined {
+		c.BearerToken = null.StringFrom(token)
 	}
 
 	envHeaders := envMap(env, "K6_PROMETHEUS_RW_HEADERS_")

--- a/pkg/remotewrite/config_test.go
+++ b/pkg/remotewrite/config_test.go
@@ -382,6 +382,40 @@ func TestOptionBasicAuth(t *testing.T) {
 	}
 }
 
+func TestOptionBearerToken(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		arg     string
+		env     map[string]string
+		jsonRaw json.RawMessage
+	}{
+		"JSON": {jsonRaw: json.RawMessage(`{"bearerToken":"my-bearer-token"}`)},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_BEARER_TOKEN": "my-bearer-token"}},
+	}
+
+	expconfig := Config{
+		ServerURL:             null.StringFrom("http://localhost:9090/api/v1/write"),
+		InsecureSkipTLSVerify: null.BoolFrom(false),
+		BearerToken:           null.StringFrom("my-bearer-token"),
+		PushInterval:          types.NullDurationFrom(5 * time.Second),
+		Headers:               make(map[string]string),
+		TrendStats:            []string{"p(99)"},
+		StaleMarkers:          null.BoolFrom(false),
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			c, err := GetConsolidatedConfig(
+				tc.jsonRaw, tc.env, tc.arg)
+			require.NoError(t, err)
+			assert.Equal(t, expconfig, c)
+		})
+	}
+}
+
 func TestOptionClientCertificate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
It amends https://github.com/grafana/xk6-output-prometheus-remote/pull/145 for really adding the support for https://github.com/grafana/xk6-output-prometheus-remote/issues/54.