### PR TITLE
Fix 32-bit build

### DIFF
--- a/pkg/remote/client.go
+++ b/pkg/remote/client.go
@@ -117,7 +117,7 @@ func newWriteRequestBody(series []*prompb.TimeSeries) ([]byte, error) {
 	}
 	if snappy.MaxEncodedLen(len(b)) < 0 {
 		return nil, fmt.Errorf("the protobuf message is too large to be handled by Snappy encoder; "+
-			"size: %d, limit: %d", len(b), 0xffffffff)
+			"size: %d, limit: %d", len(b), uint64(0xffffffff))
 	}
 	return snappy.Encode(nil, b), nil
 }

--- a/pkg/remote/client.go
+++ b/pkg/remote/client.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"time"
@@ -117,7 +118,7 @@ func newWriteRequestBody(series []*prompb.TimeSeries) ([]byte, error) {
 	}
 	if snappy.MaxEncodedLen(len(b)) < 0 {
 		return nil, fmt.Errorf("the protobuf message is too large to be handled by Snappy encoder; "+
-			"size: %d, limit: %d", len(b), uint64(0xffffffff))
+			"size: %d, limit: %d", len(b), math.MaxUint32)
 	}
 	return snappy.Encode(nil, b), nil
 }


### PR DESCRIPTION
When trying to build for 32-bit ARM (linux/arm), you get:

```
pkg/remote/client.go:120:35: cannot use 0xffffffff (untyped int constant 4294967295) as int value in argument to fmt.Errorf (overflows)
```

Pass the constant as unsigned 64-bit integer, which is what the underlying snappy code is doing (it's casting the argument to an uint64 and comparing against 0xffffffff, which in Go means it's comparing against uint64(0xffffffff)). Since this is just an error message, it shouldn't matter, but let's be consistent.