### PR TITLE
feat: support sigv4 signing

### DIFF
--- a/pkg/remote/client.go
+++ b/pkg/remote/client.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/grafana/xk6-output-prometheus-remote/pkg/sigv4"
 	"io"
 	"math"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/grafana/xk6-output-prometheus-remote/pkg/sigv4"
 
 	prompb "buf.build/gen/go/prometheus/prometheus/protocolbuffers/go"
 	"github.com/klauspost/compress/snappy"

--- a/pkg/remote/client.go
+++ b/pkg/remote/client.go
@@ -63,7 +63,11 @@ func NewWriteClient(endpoint string, cfg *HTTPConfig) (*WriteClient, error) {
 		}
 	}
 	if cfg.SigV4 != nil {
-		wc.hc.Transport = sigv4.NewRoundTripper(cfg.SigV4, wc.hc.Transport)
+		tripper, err := sigv4.NewRoundTripper(cfg.SigV4, wc.hc.Transport)
+		if err != nil {
+			return nil, err
+		}
+		wc.hc.Transport = tripper
 	}
 	return wc, nil
 }

--- a/pkg/remote/client.go
+++ b/pkg/remote/client.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/grafana/xk6-output-prometheus-remote/pkg/sigv4"
 	"io"
 	"math"
 	"net/http"
@@ -22,6 +23,7 @@ type HTTPConfig struct {
 	Timeout   time.Duration
 	TLSConfig *tls.Config
 	BasicAuth *BasicAuth
+	SigV4     *sigv4.Config
 	Headers   http.Header
 }
 
@@ -59,6 +61,9 @@ func NewWriteClient(endpoint string, cfg *HTTPConfig) (*WriteClient, error) {
 		wc.hc.Transport = &http.Transport{
 			TLSClientConfig: cfg.TLSConfig,
 		}
+	}
+	if cfg.SigV4 != nil {
+		wc.hc.Transport = sigv4.NewRoundTripper(cfg.SigV4, wc.hc.Transport)
 	}
 	return wc, nil
 }

--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/grafana/xk6-output-prometheus-remote/pkg/sigv4"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/grafana/xk6-output-prometheus-remote/pkg/sigv4"
 
 	"github.com/grafana/xk6-output-prometheus-remote/pkg/remote"
 	"go.k6.io/k6/lib/types"

--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -70,14 +70,14 @@ type Config struct {
 
 	StaleMarkers null.Bool `json:"staleMarkers"`
 
-	// Sigv4Region is the AWS region where the workspace is.
-	Sigv4Region null.String `json:"sigV4Region"`
+	// SigV4Region is the AWS region where the workspace is.
+	SigV4Region null.String `json:"sigV4Region"`
 
-	// Sigv4AccessKey is the AWS access key.
-	Sigv4AccessKey null.String `json:"sigV4AccessKey"`
+	// SigV4AccessKey is the AWS access key.
+	SigV4AccessKey null.String `json:"sigV4AccessKey"`
 
-	// Sigv4SecretKey is the AWS secret key.
-	Sigv4SecretKey null.String `json:"sigV4SecretKey"`
+	// SigV4SecretKey is the AWS secret key.
+	SigV4SecretKey null.String `json:"sigV4SecretKey"`
 }
 
 // NewConfig creates an Output's configuration.
@@ -91,9 +91,9 @@ func NewConfig() Config {
 		Headers:               make(map[string]string),
 		TrendStats:            defaultTrendStats,
 		StaleMarkers:          null.BoolFrom(false),
-		Sigv4Region:           null.NewString("", false),
-		Sigv4AccessKey:        null.NewString("", false),
-		Sigv4SecretKey:        null.NewString("", false),
+		SigV4Region:           null.NewString("", false),
+		SigV4AccessKey:        null.NewString("", false),
+		SigV4SecretKey:        null.NewString("", false),
 	}
 }
 
@@ -123,11 +123,11 @@ func (conf Config) RemoteConfig() (*remote.HTTPConfig, error) {
 		hc.TLSConfig.Certificates = []tls.Certificate{cert}
 	}
 
-	if conf.Sigv4Region.Valid && conf.Sigv4AccessKey.Valid && conf.Sigv4SecretKey.Valid {
+	if conf.SigV4Region.Valid && conf.SigV4AccessKey.Valid && conf.SigV4SecretKey.Valid {
 		hc.SigV4 = &sigv4.Config{
-			Region:             conf.Sigv4Region.String,
-			AwsAccessKeyID:     conf.Sigv4AccessKey.String,
-			AwsSecretAccessKey: conf.Sigv4SecretKey.String,
+			Region:             conf.SigV4Region.String,
+			AwsAccessKeyID:     conf.SigV4AccessKey.String,
+			AwsSecretAccessKey: conf.SigV4SecretKey.String,
 		}
 	}
 
@@ -170,16 +170,16 @@ func (conf Config) Apply(applied Config) Config {
 		conf.BearerToken = applied.BearerToken
 	}
 
-	if applied.Sigv4Region.Valid {
-		conf.Sigv4Region = applied.Sigv4Region
+	if applied.SigV4Region.Valid {
+		conf.SigV4Region = applied.SigV4Region
 	}
 
-	if applied.Sigv4AccessKey.Valid {
-		conf.Sigv4AccessKey = applied.Sigv4AccessKey
+	if applied.SigV4AccessKey.Valid {
+		conf.SigV4AccessKey = applied.SigV4AccessKey
 	}
 
-	if applied.Sigv4SecretKey.Valid {
-		conf.Sigv4SecretKey = applied.Sigv4SecretKey
+	if applied.SigV4SecretKey.Valid {
+		conf.SigV4SecretKey = applied.SigV4SecretKey
 	}
 
 	if applied.PushInterval.Valid {
@@ -332,16 +332,16 @@ func parseEnvs(env map[string]string) (Config, error) {
 		}
 	}
 
-	if sigv4Region, sigv4RegionDefined := env["K6_PROMETHEUS_RW_SIGV4_REGION"]; sigv4RegionDefined {
-		c.Sigv4Region = null.StringFrom(sigv4Region)
+	if sigV4Region, sigV4RegionDefined := env["K6_PROMETHEUS_RW_SIGV4_REGION"]; sigV4RegionDefined {
+		c.SigV4Region = null.StringFrom(sigV4Region)
 	}
 
-	if sigv4AccessKey, sigv4AccessKeyDefined := env["K6_PROMETHEUS_RW_SIGV4_ACCESS_KEY"]; sigv4AccessKeyDefined {
-		c.Sigv4AccessKey = null.StringFrom(sigv4AccessKey)
+	if sigV4AccessKey, sigV4AccessKeyDefined := env["K6_PROMETHEUS_RW_SIGV4_ACCESS_KEY"]; sigV4AccessKeyDefined {
+		c.SigV4AccessKey = null.StringFrom(sigV4AccessKey)
 	}
 
-	if sigv4SecretKey, sigv4SecretKeyDefined := env["K6_PROMETHEUS_RW_SIGV4_SECRET_KEY"]; sigv4SecretKeyDefined {
-		c.Sigv4SecretKey = null.StringFrom(sigv4SecretKey)
+	if sigV4SecretKey, sigV4SecretKeyDefined := env["K6_PROMETHEUS_RW_SIGV4_SECRET_KEY"]; sigV4SecretKeyDefined {
+		c.SigV4SecretKey = null.StringFrom(sigV4SecretKey)
 	}
 
 	if b, err := envBool(env, "K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM"); err != nil {

--- a/pkg/sigv4/const.go
+++ b/pkg/sigv4/const.go
@@ -1,0 +1,21 @@
+package sigv4
+
+const (
+	awsServiceName   = "aps"
+	signingAlgorithm = "AWS4-HMAC-SHA256"
+
+	authorizationHeaderKey = "Authorization"
+	amzDateKey             = "X-Amz-Date"
+
+	// emptyStringSHA256 is the hex encoded sha256 value of an empty string
+	emptyStringSHA256 = `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+
+	// timeFormat is the time format to be used in the X-Amz-Date header or query parameter
+	timeFormat = "20060102T150405Z"
+
+	// shortTimeFormat is the shorten time format used in the credential scope
+	shortTimeFormat = "20060102"
+
+	// contentSHAKey is the SHA256 of request body
+	contentSHAKey = "X-Amz-Content-Sha256"
+)

--- a/pkg/sigv4/const.go
+++ b/pkg/sigv4/const.go
@@ -1,7 +1,9 @@
 package sigv4
 
 const (
-	awsServiceName   = "aps"
+	// Amazon Managed Service for Prometheus
+	awsServiceName = "aps"
+
 	signingAlgorithm = "AWS4-HMAC-SHA256"
 
 	authorizationHeaderKey = "Authorization"

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -29,18 +29,7 @@ type DefaultSigner struct {
 func NewDefaultSigner(config *Config) Signer {
 	ds := &DefaultSigner{
 		config:   config,
-		noEscape: [256]bool{},
-	}
-
-	for i := 0; i < len(ds.noEscape); i++ {
-		// AWS expects every character except these to be escaped
-		ds.noEscape[i] = (i >= 'A' && i <= 'Z') ||
-			(i >= 'a' && i <= 'z') ||
-			(i >= '0' && i <= '9') ||
-			i == '-' ||
-			i == '.' ||
-			i == '_' ||
-			i == '~'
+		noEscape: buildAwsNoEscape(),
 	}
 
 	return ds
@@ -212,7 +201,7 @@ func buildCanonicalHeaders(req *http.Request) (signed http.Header, signedHeaders
 }
 
 func getCanonicalURI(u *url.URL, noEscape [256]bool) string {
-	return escapePath(getURIPath(u), false, noEscape)
+	return escapePath(getURIPath(u), noEscape)
 }
 
 func getCanonicalQueryString(u *url.URL) string {

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -1,0 +1,198 @@
+package sigv4
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+const signingAlgo = "AWS4-HMAC-SHA256"
+const awsServiceName = "aps"
+
+type Signer interface {
+	Sign(req *http.Request) error
+}
+
+type DefaultSigner struct {
+	iSO8601Date      string
+	canonicalHeaders string
+	signedHeaders    string
+	credentialScope  string
+	config           *Config
+	payloadHash      string
+}
+
+func NewDefaultSigner(config *Config) Signer {
+	now := time.Now().UTC()
+	ds := DefaultSigner{
+		iSO8601Date: now.Format("20060102T150405Z"),
+		credentialScope: fmt.Sprintf(
+			"%s/%s/%s/aws4_request",
+			now.UTC().Format("20060102"),
+			config.Region,
+			awsServiceName,
+		),
+		config: config,
+	}
+	return &ds
+}
+
+func (d *DefaultSigner) Sign(req *http.Request) error {
+	d.payloadHash = d.getPayloadHashHex(req)
+	d.addRequiredHeaders(req)
+	d.canonicalHeaders, d.signedHeaders = d.getCanonicalHeaders(req)
+	canonicalReq := d.createCanonicalRequest(req)
+	stringToSign, err := d.createStringToSign(canonicalReq)
+	if err != nil {
+		return err
+	}
+	signature := d.sign(d.createSigningKey(), stringToSign)
+	authorizationHeader := fmt.Sprintf(
+		"%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		signingAlgo,
+		d.config.AwsAccessKeyID,
+		d.credentialScope,
+		d.signedHeaders,
+		signature,
+	)
+	req.Header.Set("Authorization", authorizationHeader)
+	return nil
+}
+
+func (d *DefaultSigner) getPayloadHashHex(req *http.Request) string {
+	payloadHash, _ := d.getPayloadHash(req)
+	return payloadHash
+}
+
+func (d *DefaultSigner) getPayloadHash(req *http.Request) (string, error) {
+	if req.Body == nil {
+		return hex.EncodeToString(sha256.New().Sum(nil)), nil
+	}
+
+	reqBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		return "", err
+	}
+	reqBodyBuffer := bytes.NewReader(reqBody)
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, reqBodyBuffer); err != nil {
+		return "", err
+	}
+
+	payloadHash := hex.EncodeToString(hash.Sum(nil))
+
+	// ensuring that we keep the request body intact for next tripper
+	req.Body = io.NopCloser(bytes.NewReader(reqBody))
+
+	return payloadHash, nil
+}
+
+func (d *DefaultSigner) addRequiredHeaders(req *http.Request) {
+	req.Header.Set("Host", req.Host)
+	req.Header.Set("x-amz-date", d.iSO8601Date)
+	req.Header.Set("x-amz-content-sha256", d.payloadHash)
+}
+
+func (d *DefaultSigner) getCanonicalHeaders(req *http.Request) (string, string) {
+	var headers []string
+	var signedHeaders []string
+
+	for key, value := range req.Header {
+		lowercaseKey := strings.ToLower(key)
+		encodedValue := strings.TrimSpace(strings.Join(value, ","))
+		headers = append(headers, lowercaseKey+":"+encodedValue)
+		signedHeaders = append(signedHeaders, lowercaseKey)
+	}
+
+	sort.Strings(headers)
+	sort.Strings(signedHeaders)
+
+	canonicalHeaders := strings.Join(headers, "\n") + "\n"
+	canonicalSignedHeaders := strings.Join(signedHeaders, ";")
+	return canonicalHeaders, canonicalSignedHeaders
+}
+
+func (d *DefaultSigner) createCanonicalRequest(req *http.Request) string {
+	return strings.Join([]string{
+		req.Method,
+		d.getCanonicalURI(req.URL),
+		d.getCanonicalQueryString(req.URL),
+		d.canonicalHeaders,
+		d.signedHeaders,
+		d.payloadHash,
+	}, "\n")
+}
+
+func (d *DefaultSigner) getCanonicalURI(u *url.URL) string {
+	if u.Path == "" {
+		return "/"
+	}
+
+	// The spec requires not to encode `/`
+	segments := strings.Split(u.Path, "/")
+	for i, segment := range segments {
+		segments[i] = url.PathEscape(segment)
+	}
+
+	return strings.Join(segments, "/")
+}
+
+func (d *DefaultSigner) getCanonicalQueryString(u *url.URL) string {
+	queryParams := u.Query()
+	var queryPairs []string
+
+	for key, values := range queryParams {
+		for _, value := range values {
+			queryPairs = append(queryPairs, url.QueryEscape(key)+"="+url.QueryEscape(value))
+		}
+	}
+
+	sort.Strings(queryPairs)
+
+	return strings.Join(queryPairs, "&")
+}
+
+func (d *DefaultSigner) createStringToSign(canonicalRequest string) (string, error) {
+	hash := sha256.New()
+	if _, err := hash.Write([]byte(canonicalRequest)); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(
+		"%s\n%s\n%s\n%s",
+		signingAlgo,
+		d.iSO8601Date,
+		d.credentialScope,
+		hex.EncodeToString(hash.Sum(nil)),
+	), nil
+}
+
+func (d *DefaultSigner) createSigningKey() string {
+	signingDate := time.Now().UTC().Format("20060102")
+	dateKey := d.hmacSHA256([]byte("AWS4"+d.config.AwsSecretAccessKey), signingDate)
+	dateRegionKey := d.hmacSHA256(dateKey, d.config.Region)
+	dateRegionServiceKey := d.hmacSHA256(dateRegionKey, awsServiceName)
+	signingKey := d.hmacSHA256(dateRegionServiceKey, "aws4_request")
+	return string(signingKey)
+}
+
+func (d *DefaultSigner) hmacSHA256(key []byte, data string) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(data))
+	return h.Sum(nil)
+}
+
+func (d *DefaultSigner) sign(signingKey string, strToSign string) string {
+	h := hmac.New(sha256.New, []byte(signingKey))
+	h.Write([]byte(strToSign))
+	sig := hex.EncodeToString(h.Sum(nil))
+	return sig
+}

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -172,13 +172,22 @@ func buildCanonicalHeaders(req *http.Request) (signedHeaders, canonicalHeadersSt
 	signedHeaders = strings.Join(headers, ";")
 
 	var canonicalHeaders strings.Builder
-	for i := 0; i < len(headers); i++ {
-		if headers[i] == hostHeader {
+	for _, h := range headers {
+		if h == hostHeader {
 			canonicalHeaders.WriteString(fmt.Sprintf("%s:%s\n", hostHeader, stripExcessSpaces(host)))
 			continue
 		}
-		values := strings.Join(signed[headers[i]], ",")
-		canonicalHeaders.WriteString(fmt.Sprintf("%s:%s\n", headers[i], stripExcessSpaces(values)))
+
+		canonicalHeaders.WriteString(fmt.Sprintf("%s:", h))
+		values := signed[h]
+		for j, v := range values {
+			cleanedValue := strings.TrimSpace(stripExcessSpaces(v))
+			canonicalHeaders.WriteString(cleanedValue)
+			if j < len(values)-1 {
+				canonicalHeaders.WriteRune(',')
+			}
+		}
+		canonicalHeaders.WriteRune('\n')
 	}
 	canonicalHeadersStr = canonicalHeaders.String()
 	return signedHeaders, canonicalHeadersStr

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -15,19 +15,19 @@ import (
 	"time"
 )
 
-type Signer interface {
-	Sign(req *http.Request) error
+type signer interface {
+	sign(req *http.Request) error
 }
 
-type DefaultSigner struct {
+type defaultSigner struct {
 	config *Config
 
 	// noEscape represents the characters that AWS doesn't escape
 	noEscape [256]bool
 }
 
-func NewDefaultSigner(config *Config) Signer {
-	ds := &DefaultSigner{
+func newDefaultSigner(config *Config) signer {
+	ds := &defaultSigner{
 		config:   config,
 		noEscape: buildAwsNoEscape(),
 	}
@@ -35,7 +35,7 @@ func NewDefaultSigner(config *Config) Signer {
 	return ds
 }
 
-func (d *DefaultSigner) Sign(req *http.Request) error {
+func (d *defaultSigner) sign(req *http.Request) error {
 	now := time.Now().UTC()
 	iSO8601Date := now.Format(timeFormat)
 
@@ -81,7 +81,7 @@ func (d *DefaultSigner) Sign(req *http.Request) error {
 	return nil
 }
 
-func (d *DefaultSigner) getPayloadHash(req *http.Request) (string, error) {
+func (d *defaultSigner) getPayloadHash(req *http.Request) (string, error) {
 	if req.Body == nil {
 		return emptyStringSHA256, nil
 	}

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -34,10 +34,10 @@ func newDefaultSigner(config *Config) signer {
 		config:   config,
 		noEscape: buildAwsNoEscape(),
 		ignoredHeaders: map[string]struct{}{
-			"Authorization":   struct{}{},
-			"User-Agent":      struct{}{},
-			"X-Amzn-Trace-Id": struct{}{},
-			"Expect":          struct{}{},
+			"Authorization":   {},
+			"User-Agent":      {},
+			"X-Amzn-Trace-Id": {},
+			"Expect":          {},
 		},
 	}
 
@@ -135,7 +135,10 @@ func buildCanonicalString(method, uri, query, canonicalHeaders, signedHeaders, p
 }
 
 // buildCanonicalHeaders is mostly ported from https://github.com/aws/aws-sdk-go-v2/aws/signer/v4 buildCanonicalHeaders
-func buildCanonicalHeaders(req *http.Request, ignoredHeaders map[string]struct{}) (signedHeaders, canonicalHeadersStr string) {
+func buildCanonicalHeaders(
+	req *http.Request,
+	ignoredHeaders map[string]struct{},
+) (signedHeaders, canonicalHeadersStr string) {
 	const hostHeader, contentLengthHeader = "host", "content-length"
 	host, header, length := req.Host, req.Header, req.ContentLength
 
@@ -208,7 +211,7 @@ func getCanonicalQueryString(u *url.URL) string {
 	}
 
 	var rawQuery strings.Builder
-	rawQuery.WriteString(strings.Replace(query.Encode(), "+", "%20", -1))
+	rawQuery.WriteString(strings.ReplaceAll(query.Encode(), "+", "%20"))
 	return rawQuery.String()
 }
 

--- a/pkg/sigv4/sigv4_test.go
+++ b/pkg/sigv4/sigv4_test.go
@@ -49,7 +49,7 @@ func TestBuildCanonicalHeaders(t *testing.T) {
 		"",
 	}, "\n")
 
-	gotSignedHeaders, gotCanonicalHeader := buildCanonicalHeaders(req)
+	gotSignedHeaders, gotCanonicalHeader := buildCanonicalHeaders(req, nil)
 	assert.Equal(t, wantSignedHeader, gotSignedHeaders)
 	assert.Equal(t, wantCanonicalHeader, gotCanonicalHeader)
 

--- a/pkg/sigv4/sigv4_test.go
+++ b/pkg/sigv4/sigv4_test.go
@@ -1,11 +1,13 @@
 package sigv4
 
 import (
-	"github.com/stretchr/testify/assert"
+	"context"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildCanonicalHeaders(t *testing.T) {
@@ -18,7 +20,7 @@ func TestBuildCanonicalHeaders(t *testing.T) {
 	now := time.Now().UTC()
 	iSO8601Date := now.Format(timeFormat)
 
-	req, err := http.NewRequest("POST", endpoint, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, nil)
 	if err != nil {
 		t.Fatalf("failed to create request, %v", err)
 	}
@@ -52,5 +54,4 @@ func TestBuildCanonicalHeaders(t *testing.T) {
 	gotSignedHeaders, gotCanonicalHeader := buildCanonicalHeaders(req, nil)
 	assert.Equal(t, wantSignedHeader, gotSignedHeaders)
 	assert.Equal(t, wantCanonicalHeader, gotCanonicalHeader)
-
 }

--- a/pkg/sigv4/sigv4_test.go
+++ b/pkg/sigv4/sigv4_test.go
@@ -1,0 +1,56 @@
+package sigv4
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildCanonicalHeaders(t *testing.T) {
+	t.Parallel()
+
+	serviceName := "mockAPI"
+	region := "mock-region"
+	endpoint := "https://" + serviceName + "." + region + ".example.com"
+
+	now := time.Now().UTC()
+	iSO8601Date := now.Format(timeFormat)
+
+	req, err := http.NewRequest("POST", endpoint, nil)
+	if err != nil {
+		t.Fatalf("failed to create request, %v", err)
+	}
+
+	req.Header.Set("Host", req.Host)
+	req.Header.Set(amzDateKey, iSO8601Date)
+	req.Header.Set("InnerSpace", "   inner      space    ")
+	req.Header.Set("LeadingSpace", "    leading-space")
+	req.Header.Add("MultipleSpace", "no-space")
+	req.Header.Add("MultipleSpace", "\ttab-space")
+	req.Header.Add("MultipleSpace", "trailing-space    ")
+	req.Header.Set("NoSpace", "no-space")
+	req.Header.Set("TabSpace", "\ttab-space\t")
+	req.Header.Set("TrailingSpace", "trailing-space    ")
+	req.Header.Set("WrappedSpace", "   wrapped-space    ")
+
+	wantSignedHeader := "host;innerspace;leadingspace;multiplespace;nospace;tabspace;trailingspace;wrappedspace;x-amz-date"
+	wantCanonicalHeader := strings.Join([]string{
+		"host:mockAPI.mock-region.example.com",
+		"innerspace:inner space",
+		"leadingspace:leading-space",
+		"multiplespace:no-space,tab-space,trailing-space",
+		"nospace:no-space",
+		"tabspace:tab-space",
+		"trailingspace:trailing-space",
+		"wrappedspace:wrapped-space",
+		"x-amz-date:" + iSO8601Date,
+		"",
+	}, "\n")
+
+	gotSignedHeaders, gotCanonicalHeader := buildCanonicalHeaders(req)
+	assert.Equal(t, wantSignedHeader, gotSignedHeaders)
+	assert.Equal(t, wantCanonicalHeader, gotCanonicalHeader)
+
+}

--- a/pkg/sigv4/tripper.go
+++ b/pkg/sigv4/tripper.go
@@ -1,0 +1,35 @@
+package sigv4
+
+import (
+	"net/http"
+)
+
+type Tripper struct {
+	config *Config
+	signer Signer
+	next   http.RoundTripper
+}
+
+type Config struct {
+	Region             string
+	AwsSecretAccessKey string
+	AwsAccessKeyID     string
+}
+
+func NewRoundTripper(config *Config, next http.RoundTripper) *Tripper {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+	return &Tripper{
+		config: config,
+		next:   next,
+		signer: NewDefaultSigner(config),
+	}
+}
+
+func (c *Tripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := c.signer.Sign(req); err != nil {
+		return nil, err
+	}
+	return c.next.RoundTrip(req)
+}

--- a/pkg/sigv4/tripper.go
+++ b/pkg/sigv4/tripper.go
@@ -1,6 +1,7 @@
 package sigv4
 
 import (
+	"errors"
 	"net/http"
 )
 
@@ -16,15 +17,21 @@ type Config struct {
 	AwsAccessKeyID     string
 }
 
-func NewRoundTripper(config *Config, next http.RoundTripper) *Tripper {
+func NewRoundTripper(config *Config, next http.RoundTripper) (*Tripper, error) {
+	if config == nil {
+		return nil, errors.New("can't initialize a sigv4 round tripper with nil config")
+	}
+
 	if next == nil {
 		next = http.DefaultTransport
 	}
-	return &Tripper{
+
+	tripper := &Tripper{
 		config: config,
 		next:   next,
 		signer: NewDefaultSigner(config),
 	}
+	return tripper, nil
 }
 
 func (c *Tripper) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/pkg/sigv4/tripper.go
+++ b/pkg/sigv4/tripper.go
@@ -8,7 +8,7 @@ import (
 
 type Tripper struct {
 	config *Config
-	signer Signer
+	signer signer
 	next   http.RoundTripper
 }
 
@@ -42,13 +42,13 @@ func NewRoundTripper(config *Config, next http.RoundTripper) (*Tripper, error) {
 	tripper := &Tripper{
 		config: config,
 		next:   next,
-		signer: NewDefaultSigner(config),
+		signer: newDefaultSigner(config),
 	}
 	return tripper, nil
 }
 
 func (c *Tripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if err := c.signer.Sign(req); err != nil {
+	if err := c.signer.sign(req); err != nil {
 		return nil, err
 	}
 	return c.next.RoundTrip(req)

--- a/pkg/sigv4/tripper.go
+++ b/pkg/sigv4/tripper.go
@@ -6,12 +6,14 @@ import (
 	"strings"
 )
 
+// Tripper signs each request with sigv4
 type Tripper struct {
 	config *Config
 	signer signer
 	next   http.RoundTripper
 }
 
+// Config holds aws access configurations
 type Config struct {
 	Region             string
 	AwsAccessKeyID     string
@@ -31,6 +33,7 @@ func (c *Config) validate() error {
 	return nil
 }
 
+// NewRoundTripper creates a new sigv4 round tripper
 func NewRoundTripper(config *Config, next http.RoundTripper) (*Tripper, error) {
 	if err := config.validate(); err != nil {
 		return nil, err
@@ -48,6 +51,7 @@ func NewRoundTripper(config *Config, next http.RoundTripper) (*Tripper, error) {
 	return tripper, nil
 }
 
+// RoundTrip implements the tripper interface for sigv4 signing of requests
 func (c *Tripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err := c.signer.sign(req); err != nil {
 		return nil, err

--- a/pkg/sigv4/tripper.go
+++ b/pkg/sigv4/tripper.go
@@ -3,6 +3,7 @@ package sigv4
 import (
 	"errors"
 	"net/http"
+	"strings"
 )
 
 type Tripper struct {
@@ -22,10 +23,22 @@ func NewRoundTripper(config *Config, next http.RoundTripper) (*Tripper, error) {
 		return nil, errors.New("can't initialize a sigv4 round tripper with nil config")
 	}
 
+	if len(strings.TrimSpace(config.Region)) == 0 {
+		return nil, errors.New("sigV4 config `Region` must be set")
+	}
+
+	if len(strings.TrimSpace(config.AwsSecretAccessKey)) == 0 {
+		return nil, errors.New("sigV4 config `AwsSecretAccessKey` must be set")
+	}
+
+	if len(strings.TrimSpace(config.AwsAccessKeyID)) == 0 {
+		return nil, errors.New("sigV4 config `AwsAccessKeyID` must be set")
+	}
+
 	if next == nil {
 		next = http.DefaultTransport
 	}
-
+	
 	tripper := &Tripper{
 		config: config,
 		next:   next,

--- a/pkg/sigv4/tripper_test.go
+++ b/pkg/sigv4/tripper_test.go
@@ -45,6 +45,8 @@ func TestTripper_request_includes_required_headers(t *testing.T) {
 }
 
 func TestConfig_Validation(t *testing.T) {
+	t.Parallel()
+	
 	testCases := []struct {
 		shouldError bool
 		arg         *Config

--- a/pkg/sigv4/tripper_test.go
+++ b/pkg/sigv4/tripper_test.go
@@ -1,0 +1,35 @@
+package sigv4_test
+
+import (
+	"github.com/grafana/xk6-output-prometheus-remote/pkg/sigv4"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTripper_request_includes_required_headers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check if required headers are present
+		authorization := r.Header.Get("Authorization")
+		amzDate := r.Header.Get("x-amz-date")
+		contentSHA256 := r.Header.Get("x-amz-content-sha256")
+
+		// Respond to the request
+		w.WriteHeader(http.StatusOK)
+
+		assert.NotEmpty(t, authorization, "Authorization header should be present")
+		assert.NotEmpty(t, amzDate, "x-amz-date header should be present")
+		assert.NotEmpty(t, contentSHA256, "x-amz-content-sha256 header should be present")
+	}))
+	defer server.Close()
+	client := http.Client{}
+	client.Transport = sigv4.NewRoundTripper(&sigv4.Config{}, http.DefaultTransport)
+
+	req, err := http.NewRequest("POST", server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client.Do(req)
+}

--- a/pkg/sigv4/tripper_test.go
+++ b/pkg/sigv4/tripper_test.go
@@ -1,10 +1,12 @@
 package sigv4
 
 import (
-	"github.com/stretchr/testify/assert"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTripper_request_includes_required_headers(t *testing.T) {
@@ -36,17 +38,18 @@ func TestTripper_request_includes_required_headers(t *testing.T) {
 	}
 	client.Transport = tripper
 
-	req, err := http.NewRequest("POST", server.URL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	client.Do(req)
+	response, _ := client.Do(req)
+	_ = response.Body.Close()
 }
 
 func TestConfig_Validation(t *testing.T) {
 	t.Parallel()
-	
+
 	testCases := []struct {
 		shouldError bool
 		arg         *Config

--- a/pkg/sigv4/tripper_test.go
+++ b/pkg/sigv4/tripper_test.go
@@ -43,3 +43,52 @@ func TestTripper_request_includes_required_headers(t *testing.T) {
 
 	client.Do(req)
 }
+
+func TestConfig_Validation(t *testing.T) {
+	testCases := []struct {
+		shouldError bool
+		arg         *Config
+	}{
+		{
+			shouldError: false,
+			arg: &Config{
+				Region:             "us-east1",
+				AwsAccessKeyID:     "someAccessKey",
+				AwsSecretAccessKey: "someSecretKey",
+			},
+		},
+		{
+			shouldError: true,
+			arg:         nil,
+		},
+		{
+			shouldError: true,
+			arg: &Config{
+				Region: "us-east1",
+			},
+		},
+		{
+			shouldError: true,
+			arg: &Config{
+				Region:         "us-east1",
+				AwsAccessKeyID: "someAccessKeyId",
+			},
+		},
+		{
+			shouldError: true,
+			arg: &Config{
+				AwsAccessKeyID:     "SomeAccessKey",
+				AwsSecretAccessKey: "SomeSecretKey",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.arg.validate()
+		if tc.shouldError {
+			assert.Error(t, got)
+			continue
+		}
+		assert.NoError(t, got)
+	}
+}

--- a/pkg/sigv4/tripper_test.go
+++ b/pkg/sigv4/tripper_test.go
@@ -26,7 +26,11 @@ func TestTripper_request_includes_required_headers(t *testing.T) {
 	defer server.Close()
 
 	client := http.Client{}
-	tripper, err := NewRoundTripper(&Config{}, http.DefaultTransport)
+	tripper, err := NewRoundTripper(&Config{
+		Region:             "us-east1",
+		AwsSecretAccessKey: "xyz",
+		AwsAccessKeyID:     "abc",
+	}, http.DefaultTransport)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sigv4/util_test.go
+++ b/pkg/sigv4/util_test.go
@@ -33,6 +33,10 @@ func TestStripExcessSpaces(t *testing.T) {
 			arg:  "12     3       1abc123",
 			want: "12 3 1abc123",
 		},
+		{
+			arg:  "aaa \t bb",
+			want: "aaa bb",
+		},
 	}
 
 	for _, tc := range testcases {
@@ -98,6 +102,8 @@ func TestGetUriPath(t *testing.T) {
 }
 
 func TestGetUriPath_invalid_url_noescape(t *testing.T) {
+	t.Parallel()
+
 	arg := &url.URL{
 		Opaque: "//example.org/bucket/key-._~,!@#$%^&*()",
 	}
@@ -108,6 +114,8 @@ func TestGetUriPath_invalid_url_noescape(t *testing.T) {
 }
 
 func TestEscapePath(t *testing.T) {
+	t.Parallel()
+
 	testcases := []struct {
 		arg  string
 		want string

--- a/pkg/sigv4/util_test.go
+++ b/pkg/sigv4/util_test.go
@@ -1,0 +1,41 @@
+package sigv4
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStripExcessSpaces(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		arg  string
+		want string
+	}{
+		{
+			arg:  `AWS4-HMAC-SHA256 Credential=AKIDFAKEIDFAKEID/20160628/us-west-2/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=1234567890abcdef1234567890abcdef1234567890abcdef`,
+			want: `AWS4-HMAC-SHA256 Credential=AKIDFAKEIDFAKEID/20160628/us-west-2/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=1234567890abcdef1234567890abcdef1234567890abcdef`,
+		},
+		{
+			arg:  "a   b   c   d",
+			want: "a b c d",
+		},
+		{
+			arg:  "   abc   def   ghi   jk   ",
+			want: "abc def ghi jk",
+		},
+		{
+			arg:  "   123    456    789          101112   ",
+			want: "123 456 789 101112",
+		},
+		{
+			arg:  "12     3       1abc123",
+			want: "12 3 1abc123",
+		},
+	}
+
+	for _, tc := range testcases {
+		assert.Equal(t, tc.want, stripExcessSpaces(tc.arg))
+	}
+
+}

--- a/pkg/sigv4/util_test.go
+++ b/pkg/sigv4/util_test.go
@@ -106,3 +106,45 @@ func TestGetUriPath_invalid_url_noescape(t *testing.T) {
 	got := getURIPath(arg)
 	assert.Equal(t, want, got)
 }
+
+func TestEscapePath(t *testing.T) {
+	testcases := []struct {
+		arg  string
+		want string
+	}{
+		{
+			arg:  "/",
+			want: "/",
+		},
+		{
+			arg:  "/abc",
+			want: "/abc",
+		},
+		{
+			arg:  "/abc129",
+			want: "/abc129",
+		},
+		{
+			arg:  "/abc-def",
+			want: "/abc-def",
+		},
+		{
+			arg:  "/abc.xyz~123-456",
+			want: "/abc.xyz~123-456",
+		},
+		{
+			arg:  "/abc def-ghi",
+			want: "/abc%20def-ghi",
+		},
+		{
+			arg:  "abc!def ghi",
+			want: "abc%21def%20ghi",
+		},
+	}
+
+	noEscape := buildAwsNoEscape()
+
+	for _, tc := range testcases {
+		assert.Equal(t, tc.want, escapePath(tc.arg, noEscape))
+	}
+}

--- a/pkg/sigv4/util_test.go
+++ b/pkg/sigv4/util_test.go
@@ -1,9 +1,10 @@
 package sigv4
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStripExcessSpaces(t *testing.T) {

--- a/pkg/sigv4/utils.go
+++ b/pkg/sigv4/utils.go
@@ -22,46 +22,30 @@ func escapePath(path string, encodeSep bool, noEscape [256]bool) string {
 	return buf.String()
 }
 
-// stripExcessSpaces will rewrite the passed in slice's string values to not
-// contain multiple side-by-side spaces.
-// Ported from github.com/aws/aws-sdk-go-v2/aws/signer/internal/v4 StripExcessSpaces
+// stripExcessSpaces will remove the leading and trailing spaces, and side-by-side spaces are converted
+// into a single space.
 func stripExcessSpaces(str string) string {
-	const doubleSpace = "  "
-
-	var j, k, l, m, spaces int
-	// Trim trailing spaces
-	for j = len(str) - 1; j >= 0 && str[j] == ' '; j-- {
-	}
-
-	// Trim leading spaces
-	for k = 0; k < j && str[k] == ' '; k++ {
-	}
-	str = str[k : j+1]
-
-	// Strip multiple spaces.
-	j = strings.Index(str, doubleSpace)
-	if j < 0 {
+	if idx := strings.Index(str, "  "); idx < 0 {
 		return str
 	}
 
-	buf := []byte(str)
-	for k, m, l = j, j, len(buf); k < l; k++ {
-		if buf[k] == ' ' {
-			if spaces == 0 {
-				// First space.
-				buf[m] = buf[k]
-				m++
-			}
-			spaces++
-		} else {
-			// End of multiple spaces.
-			spaces = 0
-			buf[m] = buf[k]
-			m++
+	builder := strings.Builder{}
+	lastFoundSpace := -1
+	const space = ' '
+	str = strings.TrimSpace(str)
+	for i := 0; i < len(str); i++ {
+		if str[i] == space {
+			lastFoundSpace = i
+			continue
 		}
-	}
 
-	return string(buf[:m])
+		if lastFoundSpace > 0 && builder.Len() != 0 {
+			builder.WriteByte(space)
+		}
+		builder.WriteByte(str[i])
+		lastFoundSpace = -1
+	}
+	return builder.String()
 }
 
 // getURIPath returns the escaped URI component from the provided URL.

--- a/pkg/sigv4/utils.go
+++ b/pkg/sigv4/utils.go
@@ -43,7 +43,7 @@ func escapePath(path string, noEscape [256]bool) string {
 // stripExcessSpaces will remove the leading and trailing spaces, and side-by-side spaces are converted
 // into a single space.
 func stripExcessSpaces(str string) string {
-	if strings.Index(str, "  ") < 0 && strings.Index(str, "\t") < 0 {
+	if !strings.Contains(str, "  ") && !strings.Contains(str, "\t") {
 		return str
 	}
 

--- a/pkg/sigv4/utils.go
+++ b/pkg/sigv4/utils.go
@@ -43,7 +43,7 @@ func escapePath(path string, noEscape [256]bool) string {
 // stripExcessSpaces will remove the leading and trailing spaces, and side-by-side spaces are converted
 // into a single space.
 func stripExcessSpaces(str string) string {
-	if idx := strings.Index(str, "  "); idx < 0 {
+	if strings.Index(str, "  ") < 0 && strings.Index(str, "\t") < 0 {
 		return str
 	}
 
@@ -52,7 +52,7 @@ func stripExcessSpaces(str string) string {
 	const space = ' '
 	str = strings.TrimSpace(str)
 	for i := 0; i < len(str); i++ {
-		if str[i] == space {
+		if str[i] == space || str[i] == '\t' {
 			lastFoundSpace = i
 			continue
 		}

--- a/pkg/sigv4/utils.go
+++ b/pkg/sigv4/utils.go
@@ -49,30 +49,34 @@ func stripExcessSpaces(str string) string {
 }
 
 // getURIPath returns the escaped URI component from the provided URL.
-// Ported from github.com/aws/aws-sdk-go-v2/aws/signer/internal/v4 GetURIPath
+// Ported from inspired by github.com/aws/aws-sdk-go-v2/aws/signer/internal/v4 GetURIPath
 func getURIPath(u *url.URL) string {
 	var uriPath string
 
-	if len(u.Opaque) > 0 {
-		const schemeSep, pathSep, queryStart = "//", "/", "?"
-
-		opaque := u.Opaque
-		// Cut off the query string if present.
-		if idx := strings.Index(opaque, queryStart); idx >= 0 {
-			opaque = opaque[:idx]
-		}
-
-		// Cutout the scheme separator if present.
-		if strings.Index(opaque, schemeSep) == 0 {
-			opaque = opaque[len(schemeSep):]
-		}
-
-		// capture URI path starting with first path separator.
-		if idx := strings.Index(opaque, pathSep); idx >= 0 {
-			uriPath = opaque[idx:]
-		}
-	} else {
+	opaque := u.Opaque
+	if len(opaque) == 0 {
 		uriPath = u.EscapedPath()
+	}
+
+	if len(opaque) == 0 && len(uriPath) == 0 {
+		return "/"
+	}
+
+	const schemeSep, pathSep, queryStart = "//", "/", "?"
+
+	// Cutout the scheme separator if present.
+	if strings.Index(opaque, schemeSep) == 0 {
+		opaque = opaque[len(schemeSep):]
+	}
+
+	// Cut off the query string if present.
+	if idx := strings.Index(opaque, queryStart); idx >= 0 {
+		opaque = opaque[:idx]
+	}
+
+	// capture URI path starting with first path separator.
+	if idx := strings.Index(opaque, pathSep); idx >= 0 {
+		uriPath = opaque[idx:]
 	}
 
 	if len(uriPath) == 0 {

--- a/pkg/sigv4/utils.go
+++ b/pkg/sigv4/utils.go
@@ -7,10 +7,9 @@ import (
 	"strings"
 )
 
-var noEscape [256]bool
-
 // escapePath escapes part of a URL path in Amazon style.
-func escapePath(path string, encodeSep bool) string {
+// inspired by github.com/aws/smithy-go/encoding/httpbinding EscapePath method
+func escapePath(path string, encodeSep bool, noEscape [256]bool) string {
 	var buf bytes.Buffer
 	for i := 0; i < len(path); i++ {
 		c := path[i]
@@ -25,6 +24,7 @@ func escapePath(path string, encodeSep bool) string {
 
 // stripExcessSpaces will rewrite the passed in slice's string values to not
 // contain multiple side-by-side spaces.
+// Ported from github.com/aws/aws-sdk-go-v2/aws/signer/internal/v4 StripExcessSpaces
 func stripExcessSpaces(str string) string {
 	const doubleSpace = "  "
 
@@ -65,6 +65,7 @@ func stripExcessSpaces(str string) string {
 }
 
 // getURIPath returns the escaped URI component from the provided URL.
+// Ported from github.com/aws/aws-sdk-go-v2/aws/signer/internal/v4 GetURIPath
 func getURIPath(u *url.URL) string {
 	var uriPath string
 

--- a/pkg/sigv4/utils.go
+++ b/pkg/sigv4/utils.go
@@ -1,0 +1,98 @@
+package sigv4
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+var noEscape [256]bool
+
+// escapePath escapes part of a URL path in Amazon style.
+func escapePath(path string, encodeSep bool) string {
+	var buf bytes.Buffer
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if noEscape[c] || (c == '/' && !encodeSep) {
+			buf.WriteByte(c)
+		} else {
+			fmt.Fprintf(&buf, "%%%02X", c)
+		}
+	}
+	return buf.String()
+}
+
+// stripExcessSpaces will rewrite the passed in slice's string values to not
+// contain multiple side-by-side spaces.
+func stripExcessSpaces(str string) string {
+	const doubleSpace = "  "
+
+	var j, k, l, m, spaces int
+	// Trim trailing spaces
+	for j = len(str) - 1; j >= 0 && str[j] == ' '; j-- {
+	}
+
+	// Trim leading spaces
+	for k = 0; k < j && str[k] == ' '; k++ {
+	}
+	str = str[k : j+1]
+
+	// Strip multiple spaces.
+	j = strings.Index(str, doubleSpace)
+	if j < 0 {
+		return str
+	}
+
+	buf := []byte(str)
+	for k, m, l = j, j, len(buf); k < l; k++ {
+		if buf[k] == ' ' {
+			if spaces == 0 {
+				// First space.
+				buf[m] = buf[k]
+				m++
+			}
+			spaces++
+		} else {
+			// End of multiple spaces.
+			spaces = 0
+			buf[m] = buf[k]
+			m++
+		}
+	}
+
+	return string(buf[:m])
+}
+
+// getURIPath returns the escaped URI component from the provided URL.
+func getURIPath(u *url.URL) string {
+	var uriPath string
+
+	if len(u.Opaque) > 0 {
+		const schemeSep, pathSep, queryStart = "//", "/", "?"
+
+		opaque := u.Opaque
+		// Cut off the query string if present.
+		if idx := strings.Index(opaque, queryStart); idx >= 0 {
+			opaque = opaque[:idx]
+		}
+
+		// Cutout the scheme separator if present.
+		if strings.Index(opaque, schemeSep) == 0 {
+			opaque = opaque[len(schemeSep):]
+		}
+
+		// capture URI path starting with first path separator.
+		if idx := strings.Index(opaque, pathSep); idx >= 0 {
+			uriPath = opaque[idx:]
+		}
+	} else {
+		uriPath = u.EscapedPath()
+	}
+
+	if len(uriPath) == 0 {
+		uriPath = "/"
+	}
+
+	return uriPath
+}

--- a/pkg/sigv4/utils.go
+++ b/pkg/sigv4/utils.go
@@ -7,17 +7,35 @@ import (
 	"strings"
 )
 
+func buildAwsNoEscape() [256]bool {
+	var noEscape [256]bool
+
+	for i := 0; i < len(noEscape); i++ {
+		// AWS expects every character except these to be escaped
+		noEscape[i] = (i >= 'A' && i <= 'Z') ||
+			(i >= 'a' && i <= 'z') ||
+			(i >= '0' && i <= '9') ||
+			i == '-' ||
+			i == '.' ||
+			i == '_' ||
+			i == '~' ||
+			i == '/'
+	}
+	return noEscape
+}
+
 // escapePath escapes part of a URL path in Amazon style.
+// except for the noEscape provided.
 // inspired by github.com/aws/smithy-go/encoding/httpbinding EscapePath method
-func escapePath(path string, encodeSep bool, noEscape [256]bool) string {
+func escapePath(path string, noEscape [256]bool) string {
 	var buf bytes.Buffer
 	for i := 0; i < len(path); i++ {
 		c := path[i]
-		if noEscape[c] || (c == '/' && !encodeSep) {
+		if noEscape[c] {
 			buf.WriteByte(c)
-		} else {
-			fmt.Fprintf(&buf, "%%%02X", c)
+			continue
 		}
+		fmt.Fprintf(&buf, "%%%02X", c)
 	}
 	return buf.String()
 }


### PR DESCRIPTION
- Added Tripper to enable signing requests
- Added Signer to implement the AWS sigv4 signing standard

I based my PR on this comment https://github.com/grafana/xk6-output-prometheus-remote/pull/161#issuecomment-1934440630 and  https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html

Note: I don't have deep knowledge about the sigv4, so please provide as much feedback as possible, and I will be happy to address it :) 

Addresses: https://github.com/grafana/xk6-output-prometheus-remote/issues/93
