### PR TITLE
Fix K6 Prometheus Dashboard Metrics Quantile Mismatch by Changing Aggregation to lastNotNull

### DIFF
--- a/grafana/dashboards/k6-prometheus.json
+++ b/grafana/dashboards/k6-prometheus.json
@@ -1571,13 +1571,13 @@
               },
               "Value #D": {
                 "aggregations": [
-                  "mean"
+                  "lastNotNull"
                 ],
                 "operation": "aggregate"
               },
               "Value #E": {
                 "aggregations": [
-                  "mean"
+                  "lastNotNull"
                 ],
                 "operation": "aggregate"
               },
@@ -1618,9 +1618,9 @@
               "Value #C": "max",
               "Value #C (max)": "max",
               "Value #D": "p95",
-              "Value #D (mean)": "p95",
+              "Value #D (lastNotNull)": "p95",
               "Value #E": "p99",
-              "Value #E (mean)": "p99"
+              "Value #E (lastNotNull)": "p99"
             }
           }
         }


### PR DESCRIPTION
### Summary
This pull request updates the k6-prometheus.json file for the K6 Prometheus dashboard. Specifically, I’ve changed the aggregation method in the Requests by URL panel to use lastNotNull for quantile calculations. Previously, the aggregation used mean, which caused the dashboard to not match the K6 console output.

I discovered this issue while comparing the K6 console output and the Grafana dashboard and also discussed it in this [Grafana forum post](https://community.grafana.com/t/discrepancy-between-k6-console-output-and-grafana-dashboard-for-p90-p95-metrics/133602).

### Details
The problem was that the dashboard used the mean aggregation for quantiles, leading to discrepancies, particularly in cases where URL request durations varied more significantly.
By switching to the lastNotNull aggregation for quantile calculations, the dashboard now accurately reflects the values seen in the K6 console output.

### Screenshots and Comparison:
Here is a comparison of the K6 console output and the dashboard with different aggregation methods applied:

1. Console Output:
![k6-prometheus-console-output](https://github.com/user-attachments/assets/4c8aa9b6-7135-4132-b9f4-32c7e76b2ad7)

2. Dashboard with mean aggregation (before fix):
![k6-prometheus-mean-quantile-calculation](https://github.com/user-attachments/assets/9edcdad3-007d-4545-8628-20c6889c1b58)

3. Dashboard with lastNotNull aggregation (after fix)
![k6-prometheus-lastnotnull-quantile-calculation](https://github.com/user-attachments/assets/00eb4313-bafa-4a73-85e5-c846ca24df29)


Note that the K6 console output shows the p90 and p95 quantiles, while the dashboard shows p95 and p99. In this comparison, the p95 values can be directly compared. I have confirmed this issue across various test cases and quantile calculations.

### Steps to Reproduce the Issue:
1. **Set up a K6 Test with Thresholds:**
Define threshold tests for specific API endpoints to monitor their request durations. Below is an example using https://jsonplaceholder.typicode.com for the test:

```
import http from 'k6/http';
import { check } from 'k6';

export let options = {
  thresholds: {
    "http_req_duration{name:https://jsonplaceholder.typicode.com/posts/1}": [
      "p(95)<500",
    ],
    "http_req_duration{name:https://jsonplaceholder.typicode.com/comments/1}": [
      "p(95)<500",
    ],
    "http_req_duration{name:https://jsonplaceholder.typicode.com/todos/1}": [
      "p(95)<500",
    ],
  },
  scenarios: {
    contacts: {
      executor: "constant-arrival-rate",
      duration: "5m",
      rate: 120, 
      timeUnit: "60s",
      preAllocatedVUs: 2,
      maxVUs: 50,
    },
  },
};

export default function () {
  let api1Res = http.get("https://jsonplaceholder.typicode.com/posts/1");
  check(api1Res, { "API 1 status is 200": (r) => r.status === 200 });

  let api2Res = http.get("https://jsonplaceholder.typicode.com/comments/1");
  check(api2Res, { "API 2 status is 200": (r) => r.status === 200 });

  let api3Res = http.get("https://jsonplaceholder.typicode.com/todos/1");
  check(api3Res, { "API 3 status is 200": (r) => r.status === 200 });
}
```

2. **Run the Test with Prometheus Remote Write Enabled:**
Execute the K6 test with Prometheus remote write configured, ensuring the results are available for monitoring in your Grafana dashboard. Use the default K6 Prometheus dashboard [here](https://grafana.com/grafana/dashboards/19665-k6-prometheus/).

4. **Compare Console Output and Dashboard:**
After running the test:
    - Check the console output for p95 timings for each API endpoint.
    - Compare these values with the p95 values displayed in the Grafana dashboard.
    - Observe the differences when using the default mean aggregation method.

5. **Apply the Fix:**
Change the aggregation method in the Requests by URL panel to lastNotNull for more accurate quantile calculations. Compare the updated dashboard values with the console output again to confirm the fix.