### PR TITLE
Omit parseEnvs linter issue

### DIFF
--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -286,7 +286,8 @@ func envMap(env map[string]string, prefix string) map[string]string {
 	return result
 }
 
-func parseEnvs(env map[string]string) (Config, error) {
+// TODO: try to migrate to github.com/mstoykov/envconfig like it's done on other projects?
+func parseEnvs(env map[string]string) (Config, error) { //nolint:funlen
 	c := Config{
 		Headers: make(map[string]string),
 	}


### PR DESCRIPTION
# What?

This is a temporary omitting of the linter issue; in the future, we should refactor this method.

Triggered after https://github.com/grafana/xk6-output-prometheus-remote/pull/169, but not caused.

# Why?

To make CI green again.