### PR TITLE
fix: k6-prometheus-dashboard: Add a Max reducer function when calculating request total

### DIFF
--- a/grafana/dashboards/k6-prometheus.json
+++ b/grafana/dashboards/k6-prometheus.json
@@ -337,7 +337,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [],
+          "calcs": [
+            "max"
+          ],
           "fields": "",
           "values": false
         },
@@ -401,7 +403,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [],
+          "calcs": [
+            "max"
+          ],
           "fields": "",
           "values": false
         },


### PR DESCRIPTION
Hey, I've noticed a bug in the dashboard when displaying the total http requests.

The logs were showing a considerably higher amount of requests than the aggregation displayed in the Grafana dashboard.

```
     http_reqs......................: 2291   7.593854/s
       { name:create dialog }.......: 2287   7.580595/s
     http_reqs......................: 2346   7.757946/s
       { name:create dialog }.......: 2342   7.744718/s
     http_reqs......................: 2436   8.046441/s
       { name:create dialog }.......: 2432   8.033228/s
     http_reqs......................: 2490   8.248169/s
       { name:create dialog }.......: 2486   8.234919/s
     http_reqs......................: 2373   7.832228/s
       { name:create dialog }.......: 2369   7.819025/s
```
The aggregation displayed in Grafana should be **_2287 + 2342 + 2432 + 2486 + 2369 = 11916_**

However, we were only seeing a total of **_7141_** requests.

![bilde](https://github.com/user-attachments/assets/8397a50d-2372-42f2-9651-e977c83fccc4)

![bilde](https://github.com/user-attachments/assets/fdce60f3-da87-44ae-a82e-c78e0c2ac847)

![bilde](https://github.com/user-attachments/assets/f1b32828-9cab-44ca-a55d-bbdcc250f954)

Basically, if we queried over 13:49:30, the values of the pods no longer pushing metrics were not being taken into consideration.

![bilde](https://github.com/user-attachments/assets/1b0434e1-cb5d-4e4d-94ee-3d9cfb9b2855)

![bilde](https://github.com/user-attachments/assets/eac6a5b1-b5f9-4f9c-9137-2013628e1d05)


![bilde](https://github.com/user-attachments/assets/638ec45b-264a-42ae-be2a-1bea8ee484b0)


