### PR TITLE
Add Prometheus Pushgateway Support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - k6
     ports:
       - "9090:9090"
+    volumes:
+      - ./prometheus:/etc/prometheus
 
   grafana:
     image: grafana/grafana:10.1.2
@@ -27,3 +29,10 @@ services:
       - GF_AUTH_BASIC_ENABLED=false
     volumes:
       - ./grafana:/etc/grafana/provisioning/
+
+  pushgateway:
+    image: prom/pushgateway:v1.11.0
+    networks:
+      - k6
+    ports:
+      - "9091:9091"

--- a/pkg/remote/pushgateway_client.go
+++ b/pkg/remote/pushgateway_client.go
@@ -1,0 +1,72 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
+	"net/http"
+	"net/url"
+)
+
+type PushgatewayClient struct {
+	hc  *http.Client
+	url *url.URL
+	job string
+	cfg *HTTPConfig
+}
+
+type RegistryPusher interface {
+	Push(ctx context.Context, registries []*prometheus.Registry) error
+}
+
+var _ RegistryPusher = new(PushgatewayClient)
+
+func NewPushgatewayClient(endpoint string, job string, cfg *HTTPConfig) (*PushgatewayClient, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	pgwc := &PushgatewayClient{
+		hc: &http.Client{
+			Timeout: cfg.Timeout,
+		},
+		url: u,
+		job: job,
+		cfg: cfg,
+	}
+
+	if cfg.TLSConfig != nil {
+		pgwc.hc.Transport = &http.Transport{
+			TLSClientConfig: cfg.TLSConfig,
+		}
+	}
+
+	return pgwc, nil
+}
+
+func (pgwc *PushgatewayClient) Push(ctx context.Context, registries []*prometheus.Registry) error {
+	pusher := push.New(pgwc.url.String(), pgwc.job)
+
+	header := http.Header{}
+	if len(pgwc.cfg.Headers) > 0 {
+		header = pgwc.cfg.Headers.Clone()
+	}
+	header.Set("User-Agent", "k6-prometheus-rw-output")
+	pusher.Header(header)
+
+	if pgwc.cfg.BasicAuth != nil {
+		pusher.BasicAuth(pgwc.cfg.BasicAuth.Username, pgwc.cfg.BasicAuth.Password)
+	}
+
+	for _, registry := range registries {
+		pusher.Gatherer(registry)
+	}
+
+	if err := pusher.AddContext(ctx); err != nil {
+		return fmt.Errorf("could not push metrics to pushgateway: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/remote/pushgateway_client_test.go
+++ b/pkg/remote/pushgateway_client_test.go
@@ -1,0 +1,83 @@
+package remote
+
+import (
+	"context"
+	"github.com/prometheus/client_golang/prometheus"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPushgatewayClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CustomConfig", func(t *testing.T) {
+		t.Parallel()
+		hc := &HTTPConfig{Timeout: time.Second}
+		wc, err := NewPushgatewayClient("http://example.com/api/v1/write", "job", hc)
+		require.NoError(t, err)
+		require.NotNil(t, wc)
+		assert.Equal(t, wc.cfg, hc)
+	})
+
+	t.Run("InvalidURL", func(t *testing.T) {
+		t.Parallel()
+		wc, err := NewPushgatewayClient("fake://bad url", "job", nil)
+		require.Error(t, err)
+		assert.Nil(t, wc)
+	})
+}
+
+func TestPushgatewayPush(t *testing.T) {
+	t.Parallel()
+	h := func(rw http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Header.Get("Content-Type"), "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited")
+		assert.Equal(t, r.Header.Get("User-Agent"), "k6-prometheus-rw-output")
+		assert.Equal(t, r.Header.Get("X-MY-CUSTOM-HEADER"), "fake")
+		assert.Equal(t, r.URL.Path, "/metrics/job/myjob")
+		username, password, ok := r.BasicAuth()
+		assert.Equal(t, username, "foo")
+		assert.Equal(t, password, "bar")
+		assert.True(t, ok)
+		assert.NotEmpty(t, r.Header.Get("Content-Length"))
+
+		b, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, len(b))
+
+		rw.WriteHeader(http.StatusOK)
+	}
+	ts := httptest.NewServer(http.HandlerFunc(h))
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	c := &PushgatewayClient{
+		hc:  ts.Client(),
+		url: u,
+		job: "myjob",
+		cfg: &HTTPConfig{
+			BasicAuth: &BasicAuth{
+				Username: "foo",
+				Password: "bar",
+			},
+			Headers: map[string][]string{
+				"X-MY-CUSTOM-HEADER": {"fake"},
+			},
+		},
+	}
+
+	reg1 := prometheus.NewRegistry()
+	err = reg1.Register(prometheus.NewGauge(prometheus.GaugeOpts{Name: "test"}))
+	assert.NoError(t, err)
+
+	err = c.Push(context.Background(), []*prometheus.Registry{reg1})
+	assert.NoError(t, err)
+}

--- a/pkg/remotewrite/config.go
+++ b/pkg/remotewrite/config.go
@@ -80,6 +80,13 @@ type Config struct {
 
 	// SigV4SecretKey is the AWS secret key.
 	SigV4SecretKey null.String `json:"sigV4SecretKey"`
+
+	// UsePushgateway defines if the metrics should be exported to a Pushgateway
+	// instead of a remote-write endpoint.
+	UsePushgateway null.Bool `json:"usePushgateway"`
+
+	// PushgatewayJob defines the job name when exporting to a pushgateway
+	PushgatewayJob null.String `json:"pushgatewayJob"`
 }
 
 // NewConfig creates an Output's configuration.
@@ -221,6 +228,14 @@ func (conf Config) Apply(applied Config) Config {
 
 	if applied.ClientCertificateKey.Valid {
 		conf.ClientCertificateKey = applied.ClientCertificateKey
+	}
+
+	if applied.UsePushgateway.Valid {
+		conf.UsePushgateway = applied.UsePushgateway
+	}
+
+	if applied.PushgatewayJob.Valid {
+		conf.PushgatewayJob = applied.PushgatewayJob
 	}
 
 	return conf
@@ -371,6 +386,16 @@ func parseEnvs(env map[string]string) (Config, error) { //nolint:funlen
 		c.TrendStats = strings.Split(trendStats, ",")
 	}
 
+	if b, err := envBool(env, "K6_PROMETHEUS_RW_USE_PUSHGATEWAY"); err != nil {
+		return c, err
+	} else if b.Valid {
+		c.UsePushgateway = b
+	}
+
+	if pushgatewayJob, pushgatewayJobDefined := env["K6_PROMETHEUS_RW_PUSHGATEWAY_JOB"]; pushgatewayJobDefined {
+		c.PushgatewayJob = null.StringFrom(pushgatewayJob)
+	}
+
 	return c, nil
 }
 
@@ -426,6 +451,13 @@ func parseArg(text string) (Config, error) {
 			c.ClientCertificate = null.StringFrom(v)
 		case "clientCertificateKey":
 			c.ClientCertificateKey = null.StringFrom(v)
+
+		case "usePushgateway":
+			if err := c.UsePushgateway.UnmarshalText([]byte(v)); err != nil {
+				return c, fmt.Errorf("usePushgateway value must be true or false, not %q", v)
+			}
+		case "pushgatewayJob":
+			c.PushgatewayJob = null.StringFrom(v)
 
 		default:
 			if !strings.HasPrefix(key, "headers.") {

--- a/pkg/remotewrite/config_test.go
+++ b/pkg/remotewrite/config_test.go
@@ -592,3 +592,79 @@ func TestOptionStaleMarker(t *testing.T) {
 		})
 	}
 }
+
+func TestOptionUsePushgateway(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		arg     string
+		env     map[string]string
+		jsonRaw json.RawMessage
+	}{
+		"JSON": {jsonRaw: json.RawMessage(`{"usePushgateway":true}`)},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_USE_PUSHGATEWAY": "true"}},
+		//nolint:gocritic
+		//"Arg":  {arg: "usePushgateway=true"},
+	}
+
+	expconfig := Config{
+		ServerURL:             null.StringFrom("http://localhost:9090/api/v1/write"),
+		InsecureSkipTLSVerify: null.BoolFrom(false),
+		Username:              null.NewString("", false),
+		Password:              null.NewString("", false),
+		PushInterval:          types.NullDurationFrom(5 * time.Second),
+		Headers:               make(map[string]string),
+		TrendStats:            []string{"p(99)"},
+		StaleMarkers:          null.BoolFrom(false),
+		UsePushgateway:        null.BoolFrom(true),
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			c, err := GetConsolidatedConfig(
+				tc.jsonRaw, tc.env, tc.arg)
+			require.NoError(t, err)
+			assert.Equal(t, expconfig, c)
+		})
+	}
+}
+
+func TestOptionPushgatewayJob(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		arg     string
+		env     map[string]string
+		jsonRaw json.RawMessage
+	}{
+		"JSON": {jsonRaw: json.RawMessage(`{"pushgatewayJob":"expectedJobname"}`)},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_PUSHGATEWAY_JOB": "expectedJobname"}},
+		//nolint:gocritic
+		//"Arg":  {arg: "pushgatewayJob=expectedJobname"},
+	}
+
+	expconfig := Config{
+		ServerURL:             null.StringFrom("http://localhost:9090/api/v1/write"),
+		InsecureSkipTLSVerify: null.BoolFrom(false),
+		Username:              null.NewString("", false),
+		Password:              null.NewString("", false),
+		PushInterval:          types.NullDurationFrom(5 * time.Second),
+		Headers:               make(map[string]string),
+		TrendStats:            []string{"p(99)"},
+		StaleMarkers:          null.BoolFrom(false),
+		PushgatewayJob:        null.NewString("expectedJobname", true),
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			c, err := GetConsolidatedConfig(
+				tc.jsonRaw, tc.env, tc.arg)
+			require.NoError(t, err)
+			assert.Equal(t, expconfig, c)
+		})
+	}
+}

--- a/pkg/remotewrite/prometheus_test.go
+++ b/pkg/remotewrite/prometheus_test.go
@@ -72,10 +72,21 @@ func assertTimeSeriesEqual(t *testing.T, expected []*prompb.TimeSeries, actual [
 }
 
 // sortByLabelName sorts a slice of time series by Name label.
-//
-// TODO: remove the assumption that Name label is the first.
+func nameLabelVal(labels []*prompb.Label) string {
+	for _, label := range labels {
+		if label.Name == "__name__" {
+			return label.Value
+		}
+	}
+	panic("label with name '__name__' does not exist")
+}
 func sortByNameLabel(s []*prompb.TimeSeries) {
 	sort.Slice(s, func(i, j int) bool {
-		return s[i].Labels[0].Value <= s[j].Labels[0].Value
+		return nameLabelVal(s[i].Labels) <= nameLabelVal(s[j].Labels)
+	})
+}
+func sortWithTypeByNameLabel(s []prompbSeriesWithType) {
+	sort.Slice(s, func(i, j int) bool {
+		return nameLabelVal(s[i].Series.Labels) <= nameLabelVal(s[j].Series.Labels)
 	})
 }

--- a/pkg/remotewrite/remotewrite_test.go
+++ b/pkg/remotewrite/remotewrite_test.go
@@ -108,8 +108,16 @@ func TestOutputConvertToPbSeries(t *testing.T) {
 		},
 	}
 
-	sortByNameLabel(pbseries)
-	assert.Equal(t, exp, pbseries)
+	sortWithTypeByNameLabel(pbseries)
+
+	series := make([]*prompb.TimeSeries, len(pbseries))
+	types := make([]metrics.MetricType, len(pbseries))
+	for i, s := range pbseries {
+		series[i] = s.Series
+		types[i] = s.Type
+	}
+	assert.Equal(t, exp, series)
+	assert.Equal(t, []metrics.MetricType{metrics.Counter, metrics.Counter, metrics.Rate}, types)
 }
 
 //nolint:paralleltest,tparallel

--- a/pkg/remotewrite/trend.go
+++ b/pkg/remotewrite/trend.go
@@ -33,7 +33,7 @@ func newExtendedTrendSink(tsr TrendStatsResolver) (*extendedTrendSink, error) {
 // MapPrompb converts a k6 time series and its relative
 // Sink into the equivalent TimeSeries model as defined from
 // the Remote write specification.
-func (sink *extendedTrendSink) MapPrompb(series metrics.TimeSeries, t time.Time) []*prompb.TimeSeries {
+func (sink *extendedTrendSink) MapPrompb(series metrics.TimeSeries, t time.Time) []prompbSeriesWithType {
 	// Prometheus metric system does not support Trend so this mapping will
 	// store a counter for the number of reported values and gauges to keep
 	// track of aggregated values. Also store a sum of the values to allow
@@ -41,7 +41,7 @@ func (sink *extendedTrendSink) MapPrompb(series metrics.TimeSeries, t time.Time)
 	// TODO: when Prometheus implements support for sparse histograms, re-visit this implementation
 
 	tg := &trendAsGauges{
-		series: make([]*prompb.TimeSeries, 0, len(sink.trendStats)),
+		series: make([]prompbSeriesWithType, 0, len(sink.trendStats)),
 		// TODO: should we add the base unit suffix?
 		// It could depends from the decision for other metric types
 		// Does k6_http_req_duration_seconds_count make sense?
@@ -58,7 +58,7 @@ func (sink *extendedTrendSink) MapPrompb(series metrics.TimeSeries, t time.Time)
 
 type trendAsGauges struct {
 	// series is the slice of the converted TimeSeries.
-	series []*prompb.TimeSeries
+	series []prompbSeriesWithType
 
 	// labels are the shared labels between all the Gauges.
 	labels []*prompb.Label
@@ -92,7 +92,10 @@ func (tg *trendAsGauges) Append(suffix string, v float64) {
 		Timestamp: tg.timestamp,
 		Value:     v,
 	}
-	tg.series = append(tg.series, ts)
+	tg.series = append(tg.series, prompbSeriesWithType{
+		Series: ts,
+		Type:   metrics.Gauge,
+	})
 }
 
 // CacheNameIndex finds the __name__ label's index
@@ -180,17 +183,20 @@ func (*nativeHistogramSink) Merge(_ []byte) error {
 }
 
 // MapPrompb maps the Trend type to the experimental Native Histogram.
-func (sink *nativeHistogramSink) MapPrompb(series metrics.TimeSeries, t time.Time) []*prompb.TimeSeries {
+func (sink *nativeHistogramSink) MapPrompb(series metrics.TimeSeries, t time.Time) []prompbSeriesWithType {
 	suffix := baseUnit(series.Metric.Contains)
 	labels := MapSeries(series, suffix)
 	timestamp := t.UnixMilli()
 
-	return []*prompb.TimeSeries{
+	return []prompbSeriesWithType{
 		{
-			Labels: labels,
-			Histograms: []*prompb.Histogram{
-				histogramToHistogramProto(timestamp, sink.H),
+			Series: &prompb.TimeSeries{
+				Labels: labels,
+				Histograms: []*prompb.Histogram{
+					histogramToHistogramProto(timestamp, sink.H),
+				},
 			},
+			Type: metrics.Trend,
 		},
 	}
 }

--- a/pkg/remotewrite/trend_test.go
+++ b/pkg/remotewrite/trend_test.go
@@ -107,13 +107,15 @@ func TestTrendAsGaugesFindIxName(t *testing.T) {
 func TestNativeHistogramSinkAdd(t *testing.T) {
 	t.Parallel()
 
+	r := metrics.NewRegistry()
 	ts := metrics.TimeSeries{
 		Metric: &metrics.Metric{
 			Name:     "k6_test_metric",
 			Contains: metrics.Time,
 		},
+		Tags: r.RootTagSet(),
 	}
-	sink := newNativeHistogramSink(ts.Metric)
+	sink := newNativeHistogramSink(&ts)
 
 	// k6 passes time values with ms time unit
 	// the sink converts them to seconds.
@@ -142,7 +144,7 @@ func TestNativeHistogramSinkMapPrompb(t *testing.T) {
 		Tags: r.RootTagSet().With("tagk1", "tagv1"),
 	}
 
-	st := newNativeHistogramSink(series.Metric)
+	st := newNativeHistogramSink(&series)
 	st.Add(metrics.Sample{
 		TimeSeries: series,
 		Value:      1.52,
@@ -196,7 +198,7 @@ func TestNativeHistogramSinkMapPrompbWithValueType(t *testing.T) {
 		Tags: r.RootTagSet(),
 	}
 
-	st := newNativeHistogramSink(series.Metric)
+	st := newNativeHistogramSink(&series)
 	st.Add(metrics.Sample{
 		TimeSeries: series,
 		Value:      1.52,
@@ -230,7 +232,14 @@ func BenchmarkHistogramSinkAdd(b *testing.B) {
 		Type:     metrics.Trend,
 		Contains: metrics.Time,
 	}
-	ts := newNativeHistogramSink(m)
+
+	r := metrics.NewRegistry()
+	series := metrics.TimeSeries{
+		Metric: m,
+		Tags:   r.RootTagSet(),
+	}
+
+	ts := newNativeHistogramSink(&series)
 	s := metrics.Sample{
 		TimeSeries: metrics.TimeSeries{
 			Metric: m,

--- a/pkg/remotewrite/trend_test.go
+++ b/pkg/remotewrite/trend_test.go
@@ -165,6 +165,9 @@ func TestNativeHistogramSinkMapPrompb(t *testing.T) {
 
 	expected := `{"labels":[{"name":"__name__","value":"k6_test"},{"name":"tagk1","value":"tagv1"}],"histograms":[{"countInt":"2","positiveDeltas":["1","0"],"positiveSpans":[{"length":1,"offset":5},{"length":1,"offset":8}],"schema":3,"sum":4.66,"timestamp":"3000","zeroCountInt":"0","zeroThreshold":2.938735877055719e-39}]}`
 	assert.JSONEq(t, expected, string(b))
+
+	assert.NotNil(t, ts[0].hist)
+	assert.Equal(t, `Desc{fqName: "k6_test", help: "", constLabels: {tagk1="tagv1"}, variableLabels: []}`, (*ts[0].hist).Desc().String())
 }
 
 func BenchmarkK6TrendSinkAdd(b *testing.B) {

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'pushgateway'
+    static_configs:
+      - targets: [ 'pushgateway:9091' ]


### PR DESCRIPTION
Hi everyone,

This PR adds support for sending k6 metrics to a Prometheus Push Gateway.

**Why?**

I encountered this need while working with OpenShift's User Workload Monitoring, which provides a Prometheus instance that cannot be configured, meaning the remote write endpoint could not be enabled.

There is an existing extension for Pushgateway support: [xk6-output-prometheus-pushgateway](https://github.com/martymarron/xk6-output-prometheus-pushgateway). However, it has some limitations:

- Metrics (except gauges) report incorrect values since the extension does not track counters, histograms,... internally.
- The available Grafana dashboards do not work with this extension due to different metric names.

**Why integrate this into `xk6-output-prometheus-remote`?**

To ensure compatibility with existing dashboards and correct metric tracking, I integrated Pushgateway support into the remote-write extension. This allows us to reuse the existing logic for metric state tracking and naming conventions.

**Features of the Pushgateway support:**

- Uses the same metric names and label conventions → 100% compatible with existing Grafana dashboards
- Supports all configuration parameters (except Sigv4), including trendstats, additional headers, bearer token, basic auth
- Supports native histograms or histograms as gauges

**Notes on Native Histograms:**

Currently, the Pushgateway accepts native histograms but is not able to export them in OpenMetrics/Text format via `/metrics`. It only exports an "+Inf" bucket. This could be addressed by either:

1. Using a "classic" histogram internally when sending data to the Pushgateway.
2. Waiting until the Pushgateway supports native histogram export.

**Usage**

```sh
K6_PROMETHEUS_RW_USE_PUSHGATEWAY=true \
K6_PROMETHEUS_RW_PUSHGATEWAY_JOB=my-job \
K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9091 \
k6 run -o experimental-prometheus-rw --tag testid=my-test samples/simple.js
```

Looking forward to your feedback!